### PR TITLE
ATLASPANDA-632: add set_original_user supports

### DIFF
--- a/client/lib/idds/client/base.py
+++ b/client/lib/idds/client/base.py
@@ -169,7 +169,7 @@ class BaseRestClient(object):
         if self.original_user_cert:
             headers['X-IDDS-Auth-Usercert-Original'] = self.original_user_cert
         if self.original_user_token:
-            headers['X-IDDS-Auth-Username-Original'] = self.original_user_token
+            headers['X-IDDS-Auth-Usertoken-Original'] = self.original_user_token
 
         for retry in range(self.retries):
             try:

--- a/client/lib/idds/client/base.py
+++ b/client/lib/idds/client/base.py
@@ -68,6 +68,11 @@ class BaseRestClient(object):
 
         self.check_auth()
 
+        self.original_user_name = None
+        self.original_user_dn = None
+        self.original_user_cert = None
+        self.original_user_token = None
+
     def get_user_proxy(sellf):
         """
         Get the user proxy.
@@ -81,6 +86,19 @@ class BaseRestClient(object):
             raise exceptions.RestException("Cannot find a valid x509 proxy.")
 
         return client_proxy
+
+    def set_original_user(self, user_name=None, user_dn=None, user_cert=None, user_token=None):
+        """
+        Set original user information.
+        """
+        if user_name:
+            self.original_user_name = user_name
+        if user_dn:
+            self.original_user_dn = user_dn
+        if user_cert:
+            self.original_user_cert = user_cert
+        if user_token:
+            self.original_user_token = user_token
 
     def check_auth(self):
         """
@@ -143,6 +161,15 @@ class BaseRestClient(object):
             headers = {}
         headers['X-IDDS-Auth-Type'] = self.auth_type
         headers['X-IDDS-Auth-VO'] = self.vo
+
+        if self.original_user_name:
+            headers['X-IDDS-Auth-Username-Original'] = self.original_user_name
+        if self.original_user_dn:
+            headers['X-IDDS-Auth-Userdn-Original'] = self.original_user_dn
+        if self.original_user_cert:
+            headers['X-IDDS-Auth-Usercert-Original'] = self.original_user_cert
+        if self.original_user_token:
+            headers['X-IDDS-Auth-Username-Original'] = self.original_user_token
 
         for retry in range(self.retries):
             try:

--- a/client/lib/idds/client/clientmanager.py
+++ b/client/lib/idds/client/clientmanager.py
@@ -342,6 +342,16 @@ class ClientManager:
         else:
             logging.error("Failed to parse token information: %s" % str(token_info))
 
+    def set_original_user(self, user_name=None, user_dn=None, user_cert=None, user_token=None):
+        """
+        Set original user
+        """
+        self.setup_client()
+        self.client.set_original_user(user_name=user_name,
+                                      user_dn=user_dn,
+                                      user_cert=user_cert,
+                                      user_token=user_token)
+
     @exception_handler
     def ping(self):
         """
@@ -375,6 +385,11 @@ class ClientManager:
             'workload_id': workflow.get_workload_id(),
             'request_metadata': {'version': release_version, 'workload_id': workflow.get_workload_id(), 'workflow': workflow}
         }
+
+        if self.client.original_user_name:
+            props['username'] = self.client.original_user_name
+        if self.client.original_user_dn:
+            props['userdn'] = self.client.original_user_dn
 
         if self.auth_type == 'x509_proxy':
             workflow.add_proxy()

--- a/common/lib/idds/common/authentication.py
+++ b/common/lib/idds/common/authentication.py
@@ -359,6 +359,16 @@ class X509Authentication(BaseAuthentication):
                 return users
         return []
 
+    def get_super_user_list(self):
+        section = "Users"
+        option = "super_users"
+        if self.config and self.config.has_section(section):
+            if self.config.has_option(section, option):
+                users = self.config.get(section, option)
+                users = users.split(",")
+                return users
+        return []
+
 
 # "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=wguan/CN=667815/CN=Wen Guan/CN=1883443395"
 def get_user_name_from_dn1(dn):
@@ -480,3 +490,13 @@ def authenticate_oidc(vo, token):
         return status, data, username
     else:
         return status, data, username
+
+
+def authenticate_is_super_user(username, dn=None):
+    super_user_list = X509Authentication().get_super_user_list()
+    for super_user in super_user_list:
+        if username == super_user:
+            return True
+        if dn and super_user in dn:
+            return True
+    return False

--- a/doma/lib/idds/doma/workflowv2/domapandawork.py
+++ b/doma/lib/idds/doma/workflowv2/domapandawork.py
@@ -451,8 +451,8 @@ class DomaPanDAWork(Work):
         task_param_map['nChunksToWait'] = 1
         task_param_map['maxCpuCount'] = self.maxWalltime
         task_param_map['maxWalltime'] = self.maxWalltime
-        task_param_map['maxFailure'] = self.maxAttempt
-        task_param_map['maxAttempt'] = self.maxAttempt
+        task_param_map['maxFailure'] = self.maxAttempt if self.maxAttempt else 5
+        task_param_map['maxAttempt'] = self.maxAttempt if self.maxAttempt else 5
         task_param_map['log'] = self.task_log
         task_param_map['jobParameters'] = [
             {'type': 'constant',


### PR DESCRIPTION
add functions to set original user to support requirements when relaying idds requests or commands through panda.