### PR TITLE
replace update_contents_to_others

### DIFF
--- a/main/etc/sql/oracle_update.sql
+++ b/main/etc/sql/oracle_update.sql
@@ -275,7 +275,7 @@ CREATE OR REPLACE procedure update_contents_from_others(request_id_in NUMBER, tr
 BEGIN
     update (select c.content_id, c.substatus as c_substatus, t.substatus as t_substatus from  contents c inner join
     (select content_id, substatus from contents where request_id = request_id_in and content_relation_type = 1) t
-    on c.content_dep_id = t.content_id where c.request_id = request_id_in and c.transform_id = transform_id_in and c.substatus != t.substatus) set c_substatus = t_substatus;
+    on c.content_dep_id = t.content_id where c.request_id = request_id_in and c.transform_id = transform_id_in and c.content_relation_type = 3 and c.substatus != t.substatus) set c_substatus = t_substatus;
 END;
 
 
@@ -283,7 +283,7 @@ CREATE OR REPLACE procedure update_contents_to_others(request_id_in NUMBER, tran
 BEGIN
     update (select c.content_id, c.substatus as c_substatus, t.substatus as t_substatus from  contents c inner join
     (select content_id, substatus from contents where request_id = request_id_in and transform_id = transform_id_in and content_relation_type = 1) t
-    on c.content_dep_id = t.content_id where c.request_id = request_id_in and c.substatus != t.substatus) set c_substatus = t_substatus;
+    on c.content_dep_id = t.content_id where c.request_id = request_id_in and c.content_relation_type = 3 and c.substatus != t.substatus) set c_substatus = t_substatus;
 END;
 
 

--- a/main/lib/idds/agents/carrier/trigger.py
+++ b/main/lib/idds/agents/carrier/trigger.py
@@ -186,12 +186,13 @@ class Trigger(Poller):
                     self.update_processing(ret, pr)
 
                     if new_update_contents or ret_update_contents:
-                        self.logger.info(log_pre + "update_contents_to_others_by_dep_id")
-                        core_catalog.update_contents_to_others_by_dep_id(request_id=pr['request_id'], transform_id=pr['transform_id'])
-                        self.logger.info(log_pre + "update_contents_to_others_by_dep_id done")
+                        # self.logger.info(log_pre + "update_contents_to_others_by_dep_id")
+                        # core_catalog.update_contents_to_others_by_dep_id(request_id=pr['request_id'], transform_id=pr['transform_id'])
+                        # self.logger.info(log_pre + "update_contents_to_others_by_dep_id done")
 
                         # core_catalog.delete_contents_update(request_id=pr['request_id'], transform_id=pr['transform_id'])
-                        update_transforms = core_catalog.get_updated_transforms_by_content_status(request_id=pr['request_id'])
+                        update_transforms = core_catalog.get_updated_transforms_by_content_status(request_id=pr['request_id'],
+                                                                                                  transform_id=pr['transform_id'])
                         self.logger.info(log_pre + "update_transforms: %s" % str(update_transforms))
                         for update_transform in update_transforms:
                             if 'transform_id' in update_transform:
@@ -202,12 +203,6 @@ class Trigger(Poller):
                                                                  content={'event': 'Trigger'})
                                     self.logger.info(log_pre + "Trigger UpdateTransformEvent(transform_id: %s)" % update_transform_id)
                                     self.event_bus.send(event)
-                                else:
-                                    ret1 = self.handle_trigger_processing(pr)
-                                    new_update_contents = ret1.get('new_update_contents', None)
-                                    ret1['new_update_contents'] = None
-                                    self.update_processing(ret1, pr)
-                                    # pass
 
                     if (('processing_status' in ret and ret['processing_status'] == ProcessingStatus.Terminating)
                         or (event._content and 'Terminated' in event._content and event._content['Terminated'])):   # noqa W503

--- a/main/lib/idds/orm/base/models.py
+++ b/main/lib/idds/orm/base/models.py
@@ -833,10 +833,10 @@ def create_proc_to_update_contents():
         BEGIN
             UPDATE %s.contents set substatus = d.substatus from
             (select content_id, content_dep_id, substatus from %s.contents where request_id = request_id_in and transform_id = transform_id_in and content_relation_type = 1 and status != 0) d
-            where %s.contents.request_id = request_id_in and %s.contents.substatus != d.substatus and d.content_id = %s.contents.content_dep_id;
+            where %s.contents.request_id = request_id_in and %s.contents.content_relation_type = 3 and %s.contents.substatus != d.substatus and d.content_id = %s.contents.content_dep_id;
         END;
         $$ LANGUAGE PLPGSQL
-    """ % (DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
+    """ % (DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
            DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME))
 
     func2 = DDL("""
@@ -847,11 +847,11 @@ def create_proc_to_update_contents():
 
             UPDATE %s.contents set substatus = d.substatus from
             (select content_id, content_dep_id, substatus from %s.contents where request_id = request_id_in and content_relation_type = 1 and status != 0) d
-            where %s.contents.request_id = request_id_in and %s.contents.transform_id = transform_id_in and %s.contents.substatus != d.substatus and d.content_id = %s.contents.content_dep_id;
+            where %s.contents.request_id = request_id_in and %s.contents.transform_id = transform_id_in and %s.contents.content_relation_type = 3 and %s.contents.substatus != d.substatus and d.content_id = %s.contents.content_dep_id;
         END;
         $$ LANGUAGE PLPGSQL
     """ % (DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
-           DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME))
+           DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SCHEMA_NAME))
 
     event.listen(Content.__table__, "after_create", func1.execute_if(dialect="postgresql"))
     event.listen(Content.__table__, "after_create", func2.execute_if(dialect="postgresql"))

--- a/main/lib/idds/orm/base/models.py
+++ b/main/lib/idds/orm/base/models.py
@@ -561,7 +561,7 @@ class Content(BASE, ModelBase):
                    Index('CONTENTS_STATUS_UPDATED_IDX', 'status', 'locking', 'updated_at', 'created_at'),
                    Index('CONTENTS_ID_NAME_IDX', 'coll_id', 'scope', 'name', 'status'),
                    Index('CONTENTS_DEP_IDX', 'request_id', 'transform_id', 'content_dep_id'),
-                   Index('CONTENTS_REQ_TF_COLL_IDX', 'request_id', 'transform_id', 'workload_id', 'coll_id', 'status', 'substatus'))
+                   Index('CONTENTS_REQ_TF_COLL_IDX', 'request_id', 'transform_id', 'workload_id', 'coll_id', 'content_relation_type', 'status', 'substatus'))
 
 
 class Content_update(BASE, ModelBase):

--- a/main/lib/idds/tests/core_tests_dep_id.py
+++ b/main/lib/idds/tests/core_tests_dep_id.py
@@ -1,3 +1,4 @@
+import time                       # noqa F401
 from datetime import datetime     # noqa F401
 
 from idds.common.utils import json_dumps, setup_logging                 # noqa F401
@@ -27,5 +28,8 @@ transform_id = 26788   # 3028, 3029
 # ret = core_catalog.update_contents_from_others_by_dep_id(request_id=request_id, transform_id=transform_id)
 # print(ret)
 
-ret = core_catalog.get_updated_transforms_by_content_status(request_id=3350)
-print(ret)
+for req_id in [3350, 3407, 3414, 3420]:
+    start = time.time()
+    ret = core_catalog.get_updated_transforms_by_content_status(request_id=req_id)
+    print('request_id: %s, time: %s' % (req_id, time.time() - start))
+    print(ret)

--- a/main/lib/idds/tests/test_domapanda.py
+++ b/main/lib/idds/tests/test_domapanda.py
@@ -45,11 +45,11 @@ task_queue = 'DOMA_LSST_GOOGLE_TEST'
 # task_queue = 'DOMA_LSST_SLAC_TEST'
 task_queue = 'SLAC_Rubin'
 
-task_cloud = 'EU'
-task_queue = 'CC-IN2P3_TEST'
+# task_cloud = 'EU'
+# task_queue = 'CC-IN2P3_TEST'
 
-task_cloud = 'EU'
-task_queue = 'LANCS_TEST'
+# task_cloud = 'EU'
+# task_queue = 'LANCS_TEST'
 
 
 def randStr(chars=string.ascii_lowercase + string.digits, N=10):


### PR DESCRIPTION
(1) add locks to avoid multiple threads updating redis at the same time.
(2) replace update_contents_to_others which can cause deadlocks (even no deadlocks, it's slow because of checking deadlocks)