### PR TITLE
panda-client -> panda-client-light

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; python3 -m pip ins
 
 RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; python3 -m pip install --no-cache-dir --upgrade requests SQLAlchemy urllib3 retrying mod_wsgi flask futures stomp.py cx-Oracle  unittest2 pep8 flake8 pytest nose sphinx recommonmark sphinx-rtd-theme nevergrad
 RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; python3 -m pip install --no-cache-dir --upgrade psycopg2-binary
-RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; python3 -m pip install --no-cache-dir --upgrade rucio-clients-atlas rucio-clients panda-client
+RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; python3 -m pip install --no-cache-dir --upgrade rucio-clients-atlas rucio-clients panda-client-light
 
 
 WORKDIR /tmp/src

--- a/atlas/tools/env/environment.yml
+++ b/atlas/tools/env/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pytest           # python testing tool
   - nose             # nose test tools
   - stomp.py
-  - panda-client     # panda client
+  - panda-client-light     # panda client
   - rucio-clients
   - rucio-clients-atlas
   - idds-common==0.11.5

--- a/docs/source/users/admin_guides.rst
+++ b/docs/source/users/admin_guides.rst
@@ -26,7 +26,7 @@ Environment setup on CENTOS 7
     conda activate /opt/idds
     pip install idds-server idds-doma idds-atlas idds-monitor idds-website
 
-    pip install rucio-clients-atlas rucio-clients panda-client
+    pip install rucio-clients-atlas rucio-clients panda-client-light
     # # add "auth_type = x509_proxy" to /opt/idds/etc/rucio.cfg
 
 2. setup environment after installed.

--- a/doma/tools/env/environment.yml
+++ b/doma/tools/env/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - flake8           # Wrapper around PyFlakes&pep8
   - pytest           # python testing tool
   - nose             # nose test tools
-  - panda-client     # panda client
+  - panda-client-light     # panda client
   - idds-common==0.11.5
   - idds-workflow==0.11.5

--- a/main/tools/env/install_idds_full.sh
+++ b/main/tools/env/install_idds_full.sh
@@ -26,7 +26,7 @@ conda env create --prefix=/opt/idds -f main/tools/env/environment.yml
 conda activate /opt/idds
 conda install -c conda-forge python-gfal2
 
-pip install rucio-clients-atlas rucio-clients panda-client
+pip install rucio-clients-atlas rucio-clients panda-client-light
 # root ca.crt to  /opt/idds/etc/ca.crt
 
 pip install requests SQLAlchemy urllib3 retrying mod_wsgi flask futures stomp.py cx-Oracle  unittest2 pep8 flake8 pytest nose sphinx recommonmark sphinx-rtd-theme nevergrad


### PR DESCRIPTION
The main idea is to not install panda-client on servers due to dependency in idds-doma and idds-atlas. panda-client creates some symbolic links for end-users, and there is a mechanism not to create them on the server side. However, the mechanism doesn't work properly if panda-client is installed before panda-common. panda-client-light has been
introduced to get around the issue.