### PR TITLE
clean heartbeat before starting idds

### DIFF
--- a/main/config_default/logrotate_daemon
+++ b/main/config_default/logrotate_daemon
@@ -1,2 +1,4 @@
 #!/bin/bash
-while true; do /usr/sbin/logrotate -s /var/log/idds/logrotate.status -d /etc/logrotate.d/idds; sleep 86400; done
+# while true; do /usr/sbin/logrotate -s /var/log/idds/logrotate.status -d /etc/logrotate.d/idds; sleep 86400; done
+
+while true; do /usr/sbin/logrotate -s /var/log/idds/logrotate.status /etc/logrotate.d/idds >> /var/log/idds/logrotate.log 2>&1; sleep 3600; done

--- a/main/tools/env/clean_heartbeat.py
+++ b/main/tools/env/clean_heartbeat.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0OA
+#
+# Authors:
+# - Wen Guan, <wen.guan@cern.ch>, 2023
+
+import socket
+from idds.common.utils import pid_exists
+from idds.core import health as core_health
+
+
+def clean_heartbeat():
+    hostname = socket.getfqdn()
+    health_items = core_health.retrieve_health_items()
+    pids, pid_not_exists = [], []
+    for health_item in health_items:
+        if health_item['hostname'] == hostname:
+            pid = health_item['pid']
+            if pid not in pids:
+                pids.append(pid)
+    for pid in pids:
+        if not pid_exists(pid):
+            pid_not_exists.append(pid)
+    if pid_not_exists:
+        core_health.clean_health(hostname=hostname, pids=pid_not_exists, older_than=None)
+
+
+if __name__ == "__main__":
+    clean_heartbeat()

--- a/start-daemon.sh
+++ b/start-daemon.sh
@@ -212,6 +212,9 @@ if [ ! -f /var/lib/redis ]; then
 fi
 /usr/bin/redis-server /etc/redis.conf --supervised systemd &
 
+echo "clean heartbeats"
+python /opt/idds/tools/env/clean_heartbeat.py
+
 if [ "${IDDS_SERVICE}" == "rest" ]; then
   echo "starting iDDS ${IDDS_SERVICE} service"
   # systemctl restart httpd.service


### PR DESCRIPTION
(1) fix log rotation
(2) clean heartbeat before starting idds: idds can automatically clean heartbeats by checking the pids during start. However, for pod in k8s, every restart will have the same pids for idds daemons. As a result, iDDS thought the daemons are still running. However in fact, they are different daemons.