### PR TITLE
fix orm messages

### DIFF
--- a/main/lib/idds/core/messages.py
+++ b/main/lib/idds/core/messages.py
@@ -117,13 +117,13 @@ def delete_messages(messages, session=None):
 
 
 @transactional_session
-def update_messages(messages, session=None):
+def update_messages(messages, min_request_id=None, session=None):
     """
     Update all messages status with the given IDs.
 
     :param messages: The messages to be updated as a list of dictionaries.
     """
-    return orm_messages.update_messages(messages=messages, session=session)
+    return orm_messages.update_messages(messages=messages, min_request_id=min_request_id, session=session)
 
 
 @transactional_session

--- a/main/lib/idds/orm/messages.py
+++ b/main/lib/idds/orm/messages.py
@@ -176,7 +176,7 @@ def retrieve_messages(bulk_size=1000, msg_type=None, status=None, source=None,
             query = query.filter_by(request_id=request_id)
         else:
             if min_request_id:
-                query = query.filter_by(request_id >= min_request_id)
+                query = query.filter(models.Message.request_id >= min_request_id)
         if workload_id is not None:
             query = query.filter_by(workload_id=workload_id)
         if transform_id is not None:

--- a/main/lib/idds/tests/panda_test.py
+++ b/main/lib/idds/tests/panda_test.py
@@ -44,6 +44,8 @@ task_ids = [165290, 165295, 165299, 165728]
 task_ids = []
 task_ids = [i for i in range(166636, 166778)]
 task_ids = [166253, 166254]
+task_ids = [167759]
+task_ids = [i for i in range(167759, 167774)]
 for task_id in task_ids:
     print("Killing %s" % task_id)
     ret = Client.killTask(task_id, verbose=True)


### PR DESCRIPTION
fix orm messages by updating session.query.filter_by to session.query.filter, to avoid parameters passed wrongly.