### PR TITLE
with idds to correct the cloud

### DIFF
--- a/doma/lib/idds/doma/workflowv2/domapandawork.py
+++ b/doma/lib/idds/doma/workflowv2/domapandawork.py
@@ -792,10 +792,10 @@ class DomaPanDAWork(Work):
             if 'new_retries' in processing and processing['new_retries']:
                 new_retries = int(processing['new_retries'])
                 task_param['taskName'] = task_param['taskName'] + "_" + str(new_retries)
-            if not task_param['cloud']:
-                cloud = self.get_site_from_cloud(task_param['PandaSite'])
-                if cloud:
-                    task_param['cloud'] = cloud
+            cloud = self.get_site_from_cloud(task_param['PandaSite'])
+            if cloud and cloud != task_param['cloud']:
+                self.logger.info(f"Task cloud was set to {task_param['cloud']}, which is different from {cloud}, reset it to {cloud}")
+                task_param['cloud'] = cloud
 
             if self.has_dependency():
                 parent_tid = None

--- a/monitor/data/conf.js
+++ b/monitor/data/conf.js
@@ -1,9 +1,9 @@
 
 var appConfig = {
-    'iddsAPI_request': "https://lxplus984.cern.ch:443/idds/monitor_request/null/null",
-    'iddsAPI_transform': "https://lxplus984.cern.ch:443/idds/monitor_transform/null/null",
-    'iddsAPI_processing': "https://lxplus984.cern.ch:443/idds/monitor_processing/null/null",
-    'iddsAPI_request_detail': "https://lxplus984.cern.ch:443/idds/monitor/null/null/true/false/false",
-    'iddsAPI_transform_detail': "https://lxplus984.cern.ch:443/idds/monitor/null/null/false/true/false",
-    'iddsAPI_processing_detail': "https://lxplus984.cern.ch:443/idds/monitor/null/null/false/false/true"
+    'iddsAPI_request': "https://lxplus972.cern.ch:443/idds/monitor_request/null/null",
+    'iddsAPI_transform': "https://lxplus972.cern.ch:443/idds/monitor_transform/null/null",
+    'iddsAPI_processing': "https://lxplus972.cern.ch:443/idds/monitor_processing/null/null",
+    'iddsAPI_request_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/true/false/false",
+    'iddsAPI_transform_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/true/false",
+    'iddsAPI_processing_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/false/true"
 }


### PR DESCRIPTION
Rubin set the default cloud to US. Here iDDS needs to correct it if the task is sent to a different cloud.