### PR TITLE
Dev

### DIFF
--- a/main/lib/idds/agents/carrier/utils.py
+++ b/main/lib/idds/agents/carrier/utils.py
@@ -6,7 +6,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2022 - 2023
+# - Wen Guan, <wen.guan@cern.ch>, 2022 - 2025
 
 import concurrent.futures
 import json
@@ -307,8 +307,8 @@ def get_new_contents(request_id, transform_id, workload_id, new_input_output_map
 def get_update_content(content):
     updated_content = {'content_id': content['content_id'],
                        'request_id': content['request_id'],
-                       'status': content['substatus'],
-                       'substatus': content['substatus']}
+                       # 'substatus': content['substatus'],
+                       'status': content['substatus']}
     content['status'] = content['substatus']
     return updated_content, content
 
@@ -1465,8 +1465,8 @@ def handle_trigger_processing(processing, agent_attributes, trigger_new_updates=
             if not work.es or con['substatus'] in [ContentStatus.Available]:
                 con_dict = {'content_id': con['content_id'],
                             'request_id': con['request_id'],
-                            'status': con['substatus'],
-                            'substatus': con['substatus']}
+                            # 'substatus': con['substatus'],
+                            'status': con['substatus']}
                 if 'content_metadata' in con and con['content_metadata']:
                     con_dict['content_metadata'] = con['content_metadata']
                 new_contents_update_list.append(con_dict)

--- a/main/lib/idds/orm/contents.py
+++ b/main/lib/idds/orm/contents.py
@@ -31,6 +31,7 @@ from idds.common import exceptions
 from idds.common.constants import (ContentType, ContentStatus, ContentLocking,
                                    ContentFetchStatus, ContentRelationType)
 from idds.common.utils import group_list
+from idds.common.utils import json_dumps
 from idds.orm.base.session import read_session, transactional_session
 from idds.orm.base import models
 
@@ -508,6 +509,7 @@ def custom_bulk_update_mappings(model, parameters, session=None):
             key: (
                 value.value if isinstance(value, Enum)
                 else value.isoformat() if isinstance(value, datetime.datetime)
+                else json_dumps(value) if isinstance(value, dict)
                 else value
             )
             for key, value in row.items()

--- a/main/lib/idds/orm/contents.py
+++ b/main/lib/idds/orm/contents.py
@@ -507,7 +507,7 @@ def custom_bulk_update_mappings(model, parameters, session=None):
         updated_row = {
             key: (
                 value.value if isinstance(value, Enum)
-                else value.isoformat() if isinstance(value, datetime)
+                else value.isoformat() if isinstance(value, datetime.datetime)
                 else value
             )
             for key, value in row.items()


### PR DESCRIPTION
customize the bulk_update_mapping function and use it to replace the sqlalchemy.bulk_update_mapping function.
(the sqlalchemy.bulk_update_mapping can only use the primary key as the id, it cannot use additional id like request_id to select different partitions).