### PR TITLE
Dev

### DIFF
--- a/common/lib/idds/common/constants.py
+++ b/common/lib/idds/common/constants.py
@@ -167,6 +167,11 @@ class RequestGroupType(IDDSEnum):
     Other = 99
 
 
+class RequestAdditionalDataStorage(IDDSEnum):
+    Default = 0
+    OnDisk = 1
+
+
 class RequestStatus(IDDSEnum):
     New = 0
     Ready = 1

--- a/common/lib/idds/common/constants.py
+++ b/common/lib/idds/common/constants.py
@@ -34,6 +34,7 @@ class Sections:
     Cache = 'cache'
     Archiver = 'archiver'
     Coordinator = 'coordinator'
+    Rest = 'rest'
 
 
 class HTTP_STATUS_CODE:

--- a/common/lib/idds/common/dict_class.py
+++ b/common/lib/idds/common/dict_class.py
@@ -27,7 +27,7 @@ class DictClass(object):
         self._zip_items = []
         self._not_auto_unzip_items = []
 
-    def zip_data(self, data):
+    def zip_data(self, data, name=None):
         try:
             if type(data) in [str] and data.startswith("idds_zip:"):
                 # already zipped
@@ -149,7 +149,7 @@ class DictClass(object):
                 if key in ['logger']:
                     new_value = None
                 elif hasattr(self, 'should_zip') and self.should_zip(key):
-                    new_value = self.zip_data(value)
+                    new_value = self.zip_data(value, name=key)
                 else:
                     new_value = self.to_dict_l(value)
                 ret['attributes'][key] = new_value

--- a/common/lib/idds/common/utils.py
+++ b/common/lib/idds/common/utils.py
@@ -138,7 +138,7 @@ def get_logger(name, filename=None, loglevel=None):
 
     formatter = logging.Formatter('%(asctime)s\t%(threadName)s\t%(name)s\t%(levelname)s\t%(message)s')
 
-    handler = logging.FileHandler(filename)
+    handler = logging.handlers.RotatingFileHandler(filename)
     handler.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)

--- a/common/lib/idds/common/utils.py
+++ b/common/lib/idds/common/utils.py
@@ -32,6 +32,7 @@ import time
 
 from enum import Enum
 from functools import wraps
+from logging.handlers import RotatingFileHandler
 from itertools import groupby
 from operator import itemgetter
 from packaging import version as packaging_version
@@ -138,7 +139,7 @@ def get_logger(name, filename=None, loglevel=None):
 
     formatter = logging.Formatter('%(asctime)s\t%(threadName)s\t%(name)s\t%(levelname)s\t%(message)s')
 
-    handler = logging.handlers.RotatingFileHandler(filename)
+    handler = RotatingFileHandler(filename, maxBytes=2 * 1024 * 1024 * 1024, backupCount=3)
     handler.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)

--- a/common/lib/idds/common/utils.py
+++ b/common/lib/idds/common/utils.py
@@ -29,7 +29,6 @@ import sys
 import tarfile
 import threading
 import time
-import traceback
 
 from enum import Enum
 from functools import wraps
@@ -1142,16 +1141,3 @@ def run_command_with_timeout(command, timeout=600, stdout=sys.stdout, stderr=sys
     stderr_thread.join()
     process.wait()
     return process
-
-
-def get_additional_request_data_storage(data):
-    try:
-        max_request_data_length = 100000000
-        max_request_data_length = int(os.environ.get("MAX_REQUEST_DATA_LENGTH", max_request_data_length))
-        if len(data) > max_request_data_length:
-            additional_storage = os.environ.get("ADDITIONAL_REQUEST_DATA_STORAGE", '/tmp')
-            return additional_storage
-        return None
-    except Exception as ex:
-        print(f"is_to_store_additional_request_data_on_disk raise exception: {ex}: {traceback.format_exc()}")
-    return None

--- a/common/lib/idds/common/utils.py
+++ b/common/lib/idds/common/utils.py
@@ -6,7 +6,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2019 - 2024
+# - Wen Guan, <wen.guan@cern.ch>, 2019 - 2025
 # - Lino Oscar Gerlach, <lino.oscar.gerlach@cern.ch>, 2024
 
 import base64
@@ -29,7 +29,7 @@ import sys
 import tarfile
 import threading
 import time
-# import traceback
+import traceback
 
 from enum import Enum
 from functools import wraps
@@ -1142,3 +1142,16 @@ def run_command_with_timeout(command, timeout=600, stdout=sys.stdout, stderr=sys
     stderr_thread.join()
     process.wait()
     return process
+
+
+def get_additional_request_data_storage(data):
+    try:
+        max_request_data_length = 100000000
+        max_request_data_length = int(os.environ.get("MAX_REQUEST_DATA_LENGTH", max_request_data_length))
+        if len(data) > max_request_data_length:
+            additional_storage = os.environ.get("ADDITIONAL_REQUEST_DATA_STORAGE", '/tmp')
+            return additional_storage
+        return None
+    except Exception as ex:
+        print(f"is_to_store_additional_request_data_on_disk raise exception: {ex}: {traceback.format_exc()}")
+    return None

--- a/doma/lib/idds/doma/workflowv2/domapandawork.py
+++ b/doma/lib/idds/doma/workflowv2/domapandawork.py
@@ -6,7 +6,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2020 - 2024
+# - Wen Guan, <wen.guan@cern.ch>, 2020 - 2025
 # - Sergey Padolski, <spadolski@bnl.gov>, 2020
 
 
@@ -146,6 +146,9 @@ class DomaPanDAWork(Work):
         self.additional_task_parameters = {}
         self.additional_task_parameters_per_site = {}
 
+        self.max_dependency_map_length = 10000000
+        self.dependency_map_dir = '/tmp/idds'
+
         self.core_to_queues = {}
 
         self.zip_items = ['_dependency_map']
@@ -203,15 +206,27 @@ class DomaPanDAWork(Work):
     def dependency_map(self):
         if self.should_unzip('_dependency_map'):
             data = self.unzip_data(self._dependency_map)
-            num_inputs, num_dependencies = self.count_dependencies(data)
-            self.num_inputs = num_inputs
-            self.num_dependencies = num_dependencies
-            return data
+        else:
+            data = self._dependency_map
 
-        num_inputs, num_dependencies = self.count_dependencies(self._dependency_map)
+        if 'idds_dependency_map_file' in data and data['idds_dependency_map_file']:
+            with open(data['idds_dependency_map_file'], 'r') as fd:
+                data = json.load(fd)
+
+        num_inputs, num_dependencies = self.count_dependencies(data)
         self.num_inputs = num_inputs
         self.num_dependencies = num_dependencies
-        return self._dependency_map
+        return data
+
+    def convert_data_to_additional_data_storage(self, storage):
+        dependency_map_file = os.path.join(storage, self.get_work_name())
+        with open(dependency_map_file, 'w') as fd:
+            json.dump(self._dependency_map, fd)
+            new_dependency_map = {'idds_dependency_map_file': dependency_map_file}
+            self._dependency_map = new_dependency_map
+
+        if '_dependency_map' in self.zip_items:
+            self.zip_items.remove('_dependency_map')
 
     @dependency_map.setter
     def dependency_map(self, value):
@@ -426,6 +441,19 @@ class DomaPanDAWork(Work):
                 self.core_to_queues = self.agent_attributes['core_to_queues']
             except Exception as ex:
                 self.logger.warn(f"Failed to set core_to_queues: {ex}")
+
+        if 'max_dependency_map_length' in self.agent_attributes and self.agent_attributes['max_dependency_map_length']:
+            try:
+                self.agent_attributes['max_dependency_map_length'] = int(self.agent_attributes['max_dependency_map_length'])
+                self.max_dependency_map_length = self.agent_attributes['max_dependency_map_length']
+            except Exception as ex:
+                self.logger.warn(f"Failed to set max_dependency_map_length: {ex}")
+
+        if 'dependency_map_dir' in self.agent_attributes and self.agent_attributes['dependency_map_dir']:
+            try:
+                self.dependency_map_dir = self.agent_attributes['dependency_map_dir']
+            except Exception as ex:
+                self.logger.warn(f"Failed to set dependency_map_dir: {ex}")
 
     def depend_on(self, work):
         self.logger.debug("checking depending on")

--- a/doma/lib/idds/doma/workflowv2/domapandawork.py
+++ b/doma/lib/idds/doma/workflowv2/domapandawork.py
@@ -44,7 +44,7 @@ class DomaPanDAWork(Work):
                  input_collections=None,
                  primary_output_collection=None, other_output_collections=None,
                  output_collections=None, log_collections=None,
-                 logger=None, dependency_map=None, task_name="",
+                 logger=None, dependency_map={}, task_name="",
                  task_queue=None, queue=None, processing_type=None,
                  prodSourceLabel='test', task_type='lsst',
                  maxwalltime=90000, maxattempt=5, core_count=1,
@@ -209,9 +209,13 @@ class DomaPanDAWork(Work):
         else:
             data = self._dependency_map
 
-        if 'idds_dependency_map_file' in data and data['idds_dependency_map_file']:
+        if data is None:
+            data = {}
+
+        if data and 'idds_dependency_map_file' in data and data['idds_dependency_map_file']:
             with open(data['idds_dependency_map_file'], 'r') as fd:
                 data = json.load(fd)
+                data = self.unzip_data(data)
 
         num_inputs, num_dependencies = self.count_dependencies(data)
         self.num_inputs = num_inputs

--- a/main/lib/idds/agents/clerk/clerk.py
+++ b/main/lib/idds/agents/clerk/clerk.py
@@ -523,6 +523,7 @@ class Clerk(BaseAgent):
                          # 'expired_at': req['expired_at'],
                          'expired_at': None,
                          'internal_id': work.internal_id,
+                         'parent_internal_id': work.parent_internal_id,
                          'has_previous_conditions': has_previous_conditions,
                          'triggered_conditions': triggered_conditions,
                          'untriggered_conditions': untriggered_conditions,

--- a/main/lib/idds/core/requests.py
+++ b/main/lib/idds/core/requests.py
@@ -38,6 +38,7 @@ def create_request(scope=None, name=None, requester=None, request_type=None,
                    new_poll_period=1, update_poll_period=10, site=None,
                    new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                    campaign=None, campaign_group=None, campaign_tag=None,
+                   additional_data_storage=None,
                    processing_metadata=None):
     """
     Add a request.
@@ -69,7 +70,7 @@ def create_request(scope=None, name=None, requester=None, request_type=None,
               'new_retries': new_retries, 'update_retries': update_retries,
               'max_new_retries': max_new_retries, 'max_update_retries': max_update_retries,
               'site': site, 'campaign': campaign, 'campaign_group': campaign_group,
-              'campaign_tag': campaign_tag,
+              'campaign_tag': campaign_tag, 'additional_data_storage': additional_data_storage,
               'request_metadata': request_metadata, 'processing_metadata': processing_metadata}
     return orm_requests.create_request(**kwargs)
 
@@ -82,6 +83,7 @@ def add_request(scope=None, name=None, requester=None, request_type=None,
                 new_poll_period=1, update_poll_period=10, site=None,
                 new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                 campaign=None, campaign_group=None, campaign_tag=None,
+                additional_data_storage=None,
                 processing_metadata=None, session=None):
     """
     Add a request.
@@ -120,6 +122,7 @@ def add_request(scope=None, name=None, requester=None, request_type=None,
               'new_retries': new_retries, 'update_retries': update_retries,
               'campaign': campaign, 'campaign_group': campaign_group, 'campaign_tag': campaign_tag,
               'max_new_retries': max_new_retries, 'max_update_retries': max_update_retries,
+              'additional_data_storage': additional_data_storage,
               'request_metadata': request_metadata, 'processing_metadata': processing_metadata,
               'session': session}
     return orm_requests.add_request(**kwargs)

--- a/main/lib/idds/core/transforms.py
+++ b/main/lib/idds/core/transforms.py
@@ -36,6 +36,7 @@ def add_transform(request_id, workload_id, transform_type, transform_tag=None, p
                   new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                   parent_transform_id=None, previous_transform_id=None, current_processing_id=None,
                   internal_id=None, has_previous_conditions=None, loop_index=None,
+                  parent_internal_id=None,
                   cloned_from=None, triggered_conditions=None, untriggered_conditions=None,
                   site=None, workprogress_id=None, session=None):
     """
@@ -73,6 +74,7 @@ def add_transform(request_id, workload_id, transform_type, transform_tag=None, p
                                                 transform_metadata=transform_metadata,
                                                 site=site,
                                                 internal_id=internal_id,
+                                                parent_internal_id=parent_internal_id,
                                                 has_previous_conditions=has_previous_conditions,
                                                 loop_index=loop_index, cloned_from=cloned_from,
                                                 triggered_conditions=triggered_conditions,

--- a/main/lib/idds/orm/base/alembic/versions/6ae1f334bf41_create_contents_dep_index.py
+++ b/main/lib/idds/orm/base/alembic/versions/6ae1f334bf41_create_contents_dep_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0OA
+#
+# Authors:
+# - Wen Guan, <wen.guan@cern.ch>, 2025
+
+"""create contents dep index
+
+Revision ID: 6ae1f334bf41
+Revises: 6931b48500a2
+Create Date: 2025-03-19 14:53:30.755842+00:00
+
+"""
+from alembic import op
+from alembic import context
+
+
+# revision identifiers, used by Alembic.
+revision = '6ae1f334bf41'
+down_revision = '6931b48500a2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+
+        op.create_index("CONTENTS_REQ_TF_DEP_ID", "contents", ['content_dep_id', 'request_id', 'transform_id'], schema=schema)
+
+
+def downgrade() -> None:
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+
+        op.drop_index("CONTENTS_REQ_TF_DEP_ID", "contents", schema=schema)

--- a/main/lib/idds/orm/base/alembic/versions/abf9fce65c86_add_parent_internal_id_in_transforms.py
+++ b/main/lib/idds/orm/base/alembic/versions/abf9fce65c86_add_parent_internal_id_in_transforms.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0OA
+#
+# Authors:
+# - Wen Guan, <wen.guan@cern.ch>, 2025
+
+"""add parent_internal_id in transforms
+
+Revision ID: abf9fce65c86
+Revises: 6ae1f334bf41
+Create Date: 2025-04-11 08:37:56.638051+00:00
+
+"""
+from alembic import op
+from alembic import context
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'abf9fce65c86'
+down_revision = '6ae1f334bf41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+
+        op.add_column('requests', sa.Column('additional_data_storage', sa.String(512)), schema=schema)
+        op.add_column('transforms', sa.Column('parent_internal_id', sa.String(20)), schema=schema)
+
+
+def downgrade() -> None:
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+
+        op.drop_column('requests', 'additional_data_storage', schema=schema)
+        op.drop_column('transforms', 'parent_internal_id', schema=schema)

--- a/main/lib/idds/orm/base/models.py
+++ b/main/lib/idds/orm/base/models.py
@@ -207,6 +207,7 @@ class Request(BASE, ModelBase):
     max_update_retries = Column(Integer(), default=0)
     new_poll_period = Column(Interval(), default=datetime.timedelta(seconds=1))
     update_poll_period = Column(Interval(), default=datetime.timedelta(seconds=10))
+    additional_data_storage = Column(String(512))
     site = Column(String(50))
     locking_hostname = Column(String(50))
     locking_pid = Column(BigInteger, autoincrement=False)
@@ -354,6 +355,7 @@ class Transform(BASE, ModelBase):
     oldstatus = Column(EnumWithValue(TransformStatus), default=0)
     locking = Column(EnumWithValue(TransformLocking), nullable=False)
     retries = Column(Integer(), default=0)
+    parent_internal_id = Column(String(20))
     parent_transform_id = Column(BigInteger())
     previous_transform_id = Column(BigInteger())
     current_processing_id = Column(BigInteger())
@@ -661,7 +663,8 @@ class Content(BASE, ModelBase):
                       Index('CONTENTS_DEP_IDX', 'request_id', 'transform_id', 'content_dep_id'),
                       Index('CONTENTS_REL_IDX', 'request_id', 'content_relation_type', 'transform_id', 'substatus'),
                       Index('CONTENTS_TF_IDX', 'transform_id', 'request_id', 'coll_id', 'map_id', 'content_relation_type'),
-                      Index('CONTENTS_REQ_TF_COLL_IDX', 'request_id', 'transform_id', 'workload_id', 'coll_id', 'content_relation_type', 'status', 'substatus'))
+                      Index('CONTENTS_REQ_TF_COLL_IDX', 'request_id', 'transform_id', 'workload_id', 'coll_id', 'content_relation_type', 'status', 'substatus'),
+                      Index('CONTENTS_REQ_TF_DEP_ID', 'content_dep_id', 'request_id', 'transform_id'))
 
 
 class Content_update(BASE, ModelBase):

--- a/main/lib/idds/orm/requests.py
+++ b/main/lib/idds/orm/requests.py
@@ -6,7 +6,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2019 - 2024
+# - Wen Guan, <wen.guan@cern.ch>, 2019 - 2025
 
 
 """
@@ -34,6 +34,7 @@ def create_request(scope=None, name=None, requester=None, request_type=None,
                    new_poll_period=1, update_poll_period=10, site=None,
                    new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                    campaign=None, campaign_group=None, campaign_tag=None,
+                   additional_data_storage=None,
                    processing_metadata=None):
     """
     Create a request.
@@ -81,7 +82,7 @@ def create_request(scope=None, name=None, requester=None, request_type=None,
                                  username=username, userdn=userdn,
                                  transform_tag=transform_tag, status=status, locking=locking,
                                  priority=priority, workload_id=workload_id,
-                                 expired_at=expired_at, site=site,
+                                 expired_at=expired_at, site=site, additional_data_storage=additional_data_storage,
                                  new_retries=new_retries, update_retries=update_retries,
                                  max_new_retries=max_new_retries, max_update_retries=max_update_retries,
                                  campaign=campaign, campaign_group=campaign_group, campaign_tag=campaign_tag,
@@ -103,6 +104,7 @@ def add_request(scope=None, name=None, requester=None, request_type=None,
                 new_poll_period=1, update_poll_period=10, site=None,
                 new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                 campaign=None, campaign_group=None, campaign_tag=None,
+                additional_data_storage=None,
                 processing_metadata=None, session=None):
     """
     Add a request.
@@ -133,6 +135,7 @@ def add_request(scope=None, name=None, requester=None, request_type=None,
                                      priority=priority, workload_id=workload_id, lifetime=lifetime,
                                      new_poll_period=new_poll_period, site=site,
                                      update_poll_period=update_poll_period,
+                                     additional_data_storage=additional_data_storage,
                                      new_retries=new_retries, update_retries=update_retries,
                                      max_new_retries=max_new_retries, max_update_retries=max_update_retries,
                                      campaign=campaign, campaign_group=campaign_group, campaign_tag=campaign_tag,

--- a/main/lib/idds/orm/transforms.py
+++ b/main/lib/idds/orm/transforms.py
@@ -390,7 +390,7 @@ def get_transforms(request_id=None, workload_id=None, transform_id=None, loop_in
                 internal_ids = [internal_ids]
             if len(internal_ids) == 1:
                 internal_ids = [internal_ids[0], internal_ids[0]]
-            query = query.filter(models.Transform.internal_ids.in_(internal_ids))
+            query = query.filter(models.Transform.internal_id.in_(internal_ids))
 
         tmp = query.all()
         rets = []

--- a/main/lib/idds/orm/transforms.py
+++ b/main/lib/idds/orm/transforms.py
@@ -33,6 +33,7 @@ def create_transform(request_id, workload_id, transform_type, transform_tag=None
                      new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                      parent_transform_id=None, previous_transform_id=None, current_processing_id=None,
                      internal_id=None, has_previous_conditions=None, loop_index=None,
+                     parent_internal_id=None,
                      cloned_from=None, triggered_conditions=None, untriggered_conditions=None,
                      site=None, retries=0, expired_at=None, transform_metadata=None):
     """
@@ -61,6 +62,7 @@ def create_transform(request_id, workload_id, transform_type, transform_tag=None
                                      previous_transform_id=previous_transform_id,
                                      current_processing_id=current_processing_id,
                                      internal_id=internal_id, site=site,
+                                     parent_internal_id=parent_internal_id,
                                      has_previous_conditions=has_previous_conditions,
                                      loop_index=loop_index, cloned_from=cloned_from,
                                      triggered_conditions=triggered_conditions,
@@ -82,6 +84,7 @@ def add_transform(request_id, workload_id, transform_type, transform_tag=None, p
                   new_retries=0, update_retries=0, max_new_retries=3, max_update_retries=0,
                   parent_transform_id=None, previous_transform_id=None, current_processing_id=None,
                   internal_id=None, has_previous_conditions=None, loop_index=None,
+                  parent_internal_id=None,
                   cloned_from=None, triggered_conditions=None, untriggered_conditions=None,
                   transform_metadata=None, workprogress_id=None, site=None, session=None):
     """
@@ -116,6 +119,7 @@ def add_transform(request_id, workload_id, transform_type, transform_tag=None, p
                                          previous_transform_id=previous_transform_id,
                                          current_processing_id=current_processing_id,
                                          internal_id=internal_id, site=site,
+                                         parent_internal_id=parent_internal_id,
                                          has_previous_conditions=has_previous_conditions,
                                          loop_index=loop_index, cloned_from=cloned_from,
                                          triggered_conditions=triggered_conditions,

--- a/main/lib/idds/rest/v1/app.py
+++ b/main/lib/idds/rest/v1/app.py
@@ -20,7 +20,7 @@ from flask import Flask, Response
 from idds.common import exceptions
 # from idds.common.authentication import authenticate_x509, authenticate_oidc, authenticate_is_super_user
 from idds.common.constants import HTTP_STATUS_CODE
-from idds.common.utils import get_rest_debug
+from idds.common.utils import get_rest_debug, setup_logging
 # from idds.common.utils import get_rest_debug, setup_logging, get_logger
 from idds.core.authentication import authenticate_x509, authenticate_oidc, authenticate_is_super_user
 # from idds.common.utils import get_rest_url_prefix
@@ -156,7 +156,7 @@ def after_request(response):
 
 def create_app(auth_type=None):
 
-    # setup_logging(name='idds_app', log_file="idds_rest.log")
+    setup_logging(name='idds_app', log_file="idds_rest.log")
     # get_logger(name='idds_app', filename='idds_rest.log')
 
     # url_prefix = get_rest_url_prefix()

--- a/main/lib/idds/rest/v1/controller.py
+++ b/main/lib/idds/rest/v1/controller.py
@@ -32,6 +32,11 @@ class IDDSController(MethodView):
             self.logger = get_logger(name=self.get_class_name(), filename='idds_rest.log')
         return self.logger
 
+    def get_logger(self):
+        if hasattr(self, 'logger') and self.logger:
+            return self.logger
+        return self.setup_logger()
+
     def post(self):
         """ Not supported. """
         return Response(status=HTTP_STATUS_CODE.BadRequest, content_type='application/json')()

--- a/main/lib/idds/rest/v1/requests.py
+++ b/main/lib/idds/rest/v1/requests.py
@@ -20,7 +20,7 @@ from idds.common.constants import RequestStatus
 from idds.common.constants import (MessageType, MessageStatus,
                                    MessageSource, MessageDestination,
                                    CommandType)
-from idds.common.utils import json_loads, get_additional_request_data_storage
+from idds.common.utils import json_loads
 from idds.core.requests import (add_request, get_requests,
                                 get_request, update_request,
                                 get_request_ids_by_name)
@@ -29,6 +29,7 @@ from idds.core.commands import add_command
 from idds.rest.v1.controller import IDDSController
 
 from idds.rest.v1.utils import (convert_old_req_2_workflow_req,
+                                get_additional_request_data_storage,
                                 convert_data_to_use_additional_storage)
 
 

--- a/main/lib/idds/rest/v1/utils.py
+++ b/main/lib/idds/rest/v1/utils.py
@@ -6,9 +6,10 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2020
+# - Wen Guan, <wen.guan@cern.ch>, 2020 - 2025
 
 import copy
+import os
 
 from idds.common.constants import RequestType, RequestStatus
 from idds.common.utils import is_new_version
@@ -174,3 +175,21 @@ def convert_old_request_metadata(req):
         req['request_metadata'] = wf
         return req
     return req
+
+
+def convert_data_to_use_additional_storage(data, additional_data_storage):
+    if not data:
+        return data
+
+    if ('request_metadata' in data and isinstance(data['request_metadata'], dict) and data['request_metadata'].get('workflow')):
+        workflow = data['request_metadata']['workflow']
+        internal_id = workflow.internal_id
+        storage = os.path.join(additional_data_storage, internal_id)
+        if not os.path.exists(storage):
+            os.makedirs(storage, exist_ok=True)
+
+        data['additional_data_storage'] = storage
+        workflow.set_additional_data_storage(storage)
+        workflow.convert_data_to_additional_data_storage(storage)
+        data['request_metadata']['workflow'] = workflow
+    return data

--- a/main/lib/idds/rest/v1/utils.py
+++ b/main/lib/idds/rest/v1/utils.py
@@ -10,8 +10,10 @@
 
 import copy
 import os
+import traceback
 
-from idds.common.constants import RequestType, RequestStatus
+from idds.common.constants import RequestType, RequestStatus, Sections
+from idds.common.config import config_has_section, config_has_option, config_get
 from idds.common.utils import is_new_version
 
 from idds.workflow.work import Collection, Processing
@@ -175,6 +177,26 @@ def convert_old_request_metadata(req):
         req['request_metadata'] = wf
         return req
     return req
+
+
+def get_additional_request_data_storage(data):
+    try:
+        if config_has_section(Sections.Rest) and config_has_option(Sections.Rest, 'max_request_data_length'):
+            max_request_data_length = config_get(Sections.Rest, 'max_request_data_length')
+        else:
+            max_request_data_length = 10000000
+
+        if config_has_section(Sections.Rest) and config_has_option(Sections.Rest, 'additional_storage'):
+            additional_storage = config_get(Sections.Rest, 'additional_storage')
+        else:
+            additional_storage = '/tmp'
+
+        if len(data) > max_request_data_length:
+            return additional_storage
+        return None
+    except Exception as ex:
+        print(f"get_additional_request_data_storage raise exception: {ex}: {traceback.format_exc()}")
+    return None
 
 
 def convert_data_to_use_additional_storage(data, additional_data_storage):

--- a/main/lib/idds/rest/v1/utils.py
+++ b/main/lib/idds/rest/v1/utils.py
@@ -13,7 +13,7 @@ import os
 import traceback
 
 from idds.common.constants import RequestType, RequestStatus, Sections
-from idds.common.config import config_has_section, config_has_option, config_get
+from idds.common.config import config_has_section, config_has_option, config_get, config_get_int
 from idds.common.utils import is_new_version
 
 from idds.workflow.work import Collection, Processing
@@ -179,10 +179,10 @@ def convert_old_request_metadata(req):
     return req
 
 
-def get_additional_request_data_storage(data):
+def get_additional_request_data_storage(data, logger):
     try:
         if config_has_section(Sections.Rest) and config_has_option(Sections.Rest, 'max_request_data_length'):
-            max_request_data_length = config_get(Sections.Rest, 'max_request_data_length')
+            max_request_data_length = config_get_int(Sections.Rest, 'max_request_data_length')
         else:
             max_request_data_length = 10000000
 
@@ -191,15 +191,17 @@ def get_additional_request_data_storage(data):
         else:
             additional_storage = '/tmp'
 
-        if len(data) > max_request_data_length:
+        data_length = len(data)
+        logger.info(f"max_request_data_length: {max_request_data_length}, len(data): {data_length}")
+        if data_length > max_request_data_length:
             return additional_storage
         return None
     except Exception as ex:
-        print(f"get_additional_request_data_storage raise exception: {ex}: {traceback.format_exc()}")
+        logger.warn(f"get_additional_request_data_storage raise exception: {ex}: {traceback.format_exc()}")
     return None
 
 
-def convert_data_to_use_additional_storage(data, additional_data_storage):
+def convert_data_to_use_additional_storage(data, additional_data_storage, logger):
     if not data:
         return data
 

--- a/main/lib/idds/rest/v1/utils.py
+++ b/main/lib/idds/rest/v1/utils.py
@@ -207,7 +207,7 @@ def convert_data_to_use_additional_storage(data, additional_data_storage, logger
 
     if ('request_metadata' in data and isinstance(data['request_metadata'], dict) and data['request_metadata'].get('workflow')):
         workflow = data['request_metadata']['workflow']
-        internal_id = workflow.internal_id
+        internal_id = workflow.get_internal_id()
         storage = os.path.join(additional_data_storage, internal_id)
         if not os.path.exists(storage):
             os.makedirs(storage, exist_ok=True)

--- a/workflow/lib/idds/workflowv2/work.py
+++ b/workflow/lib/idds/workflowv2/work.py
@@ -634,6 +634,14 @@ class Work(Base):
         self.add_metadata_item('internal_id', value)
 
     @property
+    def parent_internal_id(self):
+        return self.get_metadata_item('parent_internal_id')
+
+    @parent_internal_id.setter
+    def parent_internal_id(self, value):
+        self.add_metadata_item('parent_internal_id', value)
+
+    @property
     def template_work_id(self):
         return self.get_metadata_item('template_work_id')
 
@@ -1391,6 +1399,9 @@ class Work(Base):
 
     def get_arguments(self):
         return self.arguments
+
+    def convert_data_to_additional_data_storage(self, storage):
+        pass
 
     def get_ancestry_works(self):
         return []


### PR DESCRIPTION
(1) enable separate rotation logs in idds http rest service
(2) use additional storage to store dependency_map when it's too big
(3) move the task level dependency management from clerk to transformer (before the clerk will create the next transform until its previous transforms submitted. Now clerk will create all transforms at the beginning, the transformer manages to submit the transform until the previous transforms are submitted)
(4) fix duplicated inserting in contents_update table