### PR TITLE
Dev

### DIFF
--- a/main/lib/idds/agents/carrier/finisher.py
+++ b/main/lib/idds/agents/carrier/finisher.py
@@ -194,7 +194,7 @@ class Finisher(Poller):
                                          'parameters': parameters}
                     ret = {'update_processing': update_processing,
                            'update_contents': []}
-                    self.update_processing(ret, pr)
+                    self.update_processing(ret, pr, renew_updated_at=True)
                     pro_ret = ReturnCode.Ok.value
                 else:
                     log_pre = self.get_log_prefix(pr)

--- a/main/lib/idds/agents/carrier/iutils.py
+++ b/main/lib/idds/agents/carrier/iutils.py
@@ -70,8 +70,12 @@ def handle_update_iprocessing(processing, agent_attributes, plugin=None, max_upd
     workload_id = processing['workload_id']
 
     try:
-        status = plugin.poll(workload_id, logger=logger, log_prefix=log_prefix)
-        logger.info(log_prefix + "poll work (status: %s, workload_id: %s)" % (status, workload_id))
+        if workload_id is None:
+            logger.info(log_prefix + f"poll work (workload_id: {workload_id}) workload_id is None, fail the task")
+            status = ProcessingStatus.Failed
+        else:
+            status = plugin.poll(workload_id, logger=logger, log_prefix=log_prefix)
+            logger.info(log_prefix + "poll work (status: %s, workload_id: %s)" % (status, workload_id))
     except Exception as ex:
         err_msg = "poll work failed with exception: %s" % (ex)
         logger.error(log_prefix + err_msg)

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -114,31 +114,6 @@ class BaseSubmitter(object):
         if task_param_map['maxFailure'] < work.max_attempt:
             task_param_map['maxFailure'] = work.max_attempt
 
-        if work.output_dataset_name:
-            if not work.output_dataset_name.endswith("/"):
-                work.output_dataset_name = work.output_dataset_name + "/"
-
-        # if work.enable_separate_log:
-        if True:
-            if work.output_dataset_name:
-                log_dataset_name = re.sub('/$', '.log/', work.output_dataset_name)
-            else:
-                log_dataset_name = f"Panda.iworkflow.{work.request_id}/"   # "PandaJob_#{pandaid}/"
-
-            log_dataset_name = log_dataset_name.replace("$WORKFLOWID", str(work.request_id))
-            log_dataset_name_no_scope = log_dataset_name.split(":")[-1]
-
-            logging.debug(f"BaseSubmitter enable_separate_log: {work.enable_separate_log}")
-            task_param_map['log'] = {"dataset": log_dataset_name,
-                                     "container": log_dataset_name,
-                                     # "destination": "local",
-                                     "param_type": "log",
-                                     # "token": "local",
-                                     "type": "template",
-                                     # "value": "log.tgz"}
-                                     # 'value': '{0}.$JEDITASKID.${{SN}}.log.tgz'.format(log_dataset_name[:-1])
-                                     'value': '{0}.${{SN}}.log.tgz'.format(log_dataset_name_no_scope[:-1])
-                                     }
         task_param_map['jobParameters'] = [
             {'type': 'constant',
              'value': executable,  # noqa: E501
@@ -157,6 +132,10 @@ class BaseSubmitter(object):
             }
             task_param_map['jobParameters'].append(tmp_dict)
             task_param_map['dsForIN'] = input_dataset_name
+
+        if work.output_dataset_name:
+            if not work.output_dataset_name.endswith("/"):
+                work.output_dataset_name = work.output_dataset_name + "/"
 
         if work.output_dataset_name and work.output_file_name:
             output_dataset_name = work.output_dataset_name.replace("$WORKFLOWID", str(work.request_id))
@@ -182,6 +161,30 @@ class BaseSubmitter(object):
                     "value": ' --output_map "{0}"'.format(str(output_map)),
                 },
             ]
+
+        # if work.enable_separate_log:
+        if True:
+            if work.log_dataset_name:
+                log_dataset_name = work.log_dataset_name
+            elif work.output_dataset_name:
+                log_dataset_name = re.sub('/$', '.log/', work.output_dataset_name)
+            else:
+                log_dataset_name = f"Panda.iworkflow.{work.request_id}/"   # "PandaJob_#{pandaid}/"
+
+            log_dataset_name = log_dataset_name.replace("$WORKFLOWID", str(work.request_id))
+            log_dataset_name_no_scope = log_dataset_name.split(":")[-1]
+
+            logging.debug(f"BaseSubmitter enable_separate_log: {work.enable_separate_log}")
+            task_param_map['log'] = {"dataset": log_dataset_name,
+                                     "container": log_dataset_name,
+                                     # "destination": "local",
+                                     "param_type": "log",
+                                     # "token": "local",
+                                     "type": "template",
+                                     # "value": "log.tgz"}
+                                     # 'value': '{0}.$JEDITASKID.${{SN}}.log.tgz'.format(log_dataset_name[:-1])
+                                     'value': '{0}.${{SN}}.log.tgz'.format(log_dataset_name_no_scope[:-1])
+                                     }
 
         task_param_map['reqID'] = work.request_id
 

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -160,7 +160,7 @@ class BaseSubmitter(object):
 
         if work.output_dataset_name and work.output_file_name:
             output_dataset_name = work.output_dataset_name.replace("$WORKFLOWID", str(work.request_id))
-            output_dataset_name_no_scope = work.output_dataset_name.split(":")[-1]
+            output_dataset_name_no_scope = output_dataset_name.split(":")[-1]
             output_file_name = f"{output_dataset_name_no_scope[:-1]}_${{SN/P}}.{work.output_file_name}"
             tmp_dict = {"dataset": output_dataset_name,
                         "container": output_dataset_name,

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -53,35 +53,6 @@ class BaseSubmitter(object):
 
         task_param_map['workingGroup'] = work.working_group
 
-        # task_param_map['nFilesPerJob'] = 1
-        if in_files:
-            # if has_dependencies:
-            #     task_param_map['inputPreStaging'] = True
-            task_param_map['nFiles'] = len(in_files)
-            task_param_map['noInput'] = True
-            task_param_map['pfnList'] = in_files
-            task_param_map['nFilesPerJob'] = 1
-        elif work.input_datasets:
-            for input_file_name, input_dataset_name in work.input_datasets.items():
-                input_dataset_name = work.input_dataset_name.replace("$WORKFLOWID", str(work.request_id))
-                tmp_dict = {
-                    "type": "template",
-                    "param_type": "input",
-                    "exclude": "\.log\.tgz(\.\d+)*$",   # noqa W605
-                    "expand": True,
-                    "value": '--inputs "${IN/T}" --input_map %s' % input_file_name,
-                    "dataset": input_dataset_name
-                }
-                task_param_map['jobParameters'].append(tmp_dict)
-                task_param_map['dsForIN'] = input_dataset_name
-        else:
-            # task_param_map['inputPreStaging'] = True
-            in_files = [json.dumps('pseudo_file')]
-            task_param_map['nFiles'] = len(in_files)
-            task_param_map['noInput'] = True
-            task_param_map['pfnList'] = in_files
-            task_param_map['nFilesPerJob'] = 1
-
         if work.num_events:
             task_param_map['nEvents'] = work.num_events
             if work.num_events_per_job:
@@ -134,6 +105,37 @@ class BaseSubmitter(object):
              'value': executable,  # noqa: E501
              },
         ]
+
+        # task_param_map['nFilesPerJob'] = 1
+        if in_files:
+            # if has_dependencies:
+            #     task_param_map['inputPreStaging'] = True
+            task_param_map['nFiles'] = len(in_files)
+            task_param_map['noInput'] = True
+            task_param_map['pfnList'] = in_files
+            task_param_map['nFilesPerJob'] = 1
+        elif work.input_datasets:
+            for i, (input_file_name, input_dataset_name) in enumerate(work.input_datasets.items()):
+                input_dataset_name = input_dataset_name.replace("$WORKFLOWID", str(work.request_id))
+                tmp_dict = {
+                    "type": "template",
+                    "param_type": "input",
+                    "exclude": "\.log\.tgz(\.\d+)*$",   # noqa W605
+                    "expand": True,
+                    # "value": '--inputs%s "${IN/T}" --input_map%s %s' % (i, i, input_file_name),
+                    "value": f'--inputs{i} "${{IN/T}}" --input_map{i} {input_file_name}',
+                    "dataset": input_dataset_name
+                }
+                i += 1
+                task_param_map['jobParameters'].append(tmp_dict)
+                task_param_map['dsForIN'] = input_dataset_name
+        else:
+            # task_param_map['inputPreStaging'] = True
+            in_files = [json.dumps('pseudo_file')]
+            task_param_map['nFiles'] = len(in_files)
+            task_param_map['noInput'] = True
+            task_param_map['pfnList'] = in_files
+            task_param_map['nFilesPerJob'] = 1
 
         if work.output_dataset_name:
             if not work.output_dataset_name.endswith("/"):

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -123,7 +123,7 @@ class BaseSubmitter(object):
             if work.output_dataset_name:
                 log_dataset_name = re.sub('/$', '.log/', work.output_dataset_name)
             else:
-                log_dataset_name = "PandaJob_iworkflow/"   # "PandaJob_#{pandaid}/"
+                log_dataset_name = f"Panda.iworkflow.{work.request_id}/"   # "PandaJob_#{pandaid}/"
 
             log_dataset_name = log_dataset_name.replace("$WORKFLOWID", str(work.request_id))
             log_dataset_name_no_scope = log_dataset_name.split(":")[-1]

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -125,6 +125,9 @@ class BaseSubmitter(object):
             else:
                 log_dataset_name = "PandaJob_iworkflow/"   # "PandaJob_#{pandaid}/"
 
+            log_dataset_name = log_dataset_name.replace("$WORKFLOWID", work.request_id)
+            log_dataset_name_no_scope = log_dataset_name.split(":")[-1]
+
             logging.debug(f"BaseSubmitter enable_separate_log: {work.enable_separate_log}")
             task_param_map['log'] = {"dataset": log_dataset_name,
                                      "container": log_dataset_name,
@@ -134,7 +137,7 @@ class BaseSubmitter(object):
                                      "type": "template",
                                      # "value": "log.tgz"}
                                      # 'value': '{0}.$JEDITASKID.${{SN}}.log.tgz'.format(log_dataset_name[:-1])
-                                     'value': '{0}.${{SN}}.log.tgz'.format(log_dataset_name[:-1])
+                                     'value': '{0}.${{SN}}.log.tgz'.format(log_dataset_name_no_scope[:-1])
                                      }
         task_param_map['jobParameters'] = [
             {'type': 'constant',
@@ -143,21 +146,24 @@ class BaseSubmitter(object):
         ]
 
         if work.input_dataset_name:
+            input_dataset_name = work.input_dataset_name.replace("$WORKFLOWID", work.request_id)
             tmp_dict = {
                 "type": "template",
                 "param_type": "input",
                 "exclude": "\.log\.tgz(\.\d+)*$",   # noqa W605
                 "expand": True,
                 "value": '-i "${IN/T}"',
-                "dataset": work.input_dataset_name
+                "dataset": input_dataset_name
             }
             task_param_map['jobParameters'].append(tmp_dict)
-            task_param_map['dsForIN'] = work.input_dataset_name
+            task_param_map['dsForIN'] = input_dataset_name
 
         if work.output_dataset_name and work.output_file_name:
-            output_file_name = f"{work.output_dataset_name[:-1]}_${{SN/P}}.{work.output_file_name}"
-            tmp_dict = {"dataset": work.output_dataset_name,
-                        "container": work.output_dataset_name,
+            output_dataset_name = work.output_dataset_name.replace("$WORKFLOWID", work.request_id)
+            output_dataset_name_no_scope = work.output_dataset_name.split(":")[-1]
+            output_file_name = f"{output_dataset_name_no_scope[:-1]}_${{SN/P}}.{work.output_file_name}"
+            tmp_dict = {"dataset": output_dataset_name,
+                        "container": output_dataset_name,
                         # "destination": "local",
                         "param_type": "output",
                         # "token": "local",

--- a/main/lib/idds/agents/carrier/plugins/base.py
+++ b/main/lib/idds/agents/carrier/plugins/base.py
@@ -125,7 +125,7 @@ class BaseSubmitter(object):
             else:
                 log_dataset_name = "PandaJob_iworkflow/"   # "PandaJob_#{pandaid}/"
 
-            log_dataset_name = log_dataset_name.replace("$WORKFLOWID", work.request_id)
+            log_dataset_name = log_dataset_name.replace("$WORKFLOWID", str(work.request_id))
             log_dataset_name_no_scope = log_dataset_name.split(":")[-1]
 
             logging.debug(f"BaseSubmitter enable_separate_log: {work.enable_separate_log}")
@@ -146,7 +146,7 @@ class BaseSubmitter(object):
         ]
 
         if work.input_dataset_name:
-            input_dataset_name = work.input_dataset_name.replace("$WORKFLOWID", work.request_id)
+            input_dataset_name = work.input_dataset_name.replace("$WORKFLOWID", str(work.request_id))
             tmp_dict = {
                 "type": "template",
                 "param_type": "input",
@@ -159,7 +159,7 @@ class BaseSubmitter(object):
             task_param_map['dsForIN'] = input_dataset_name
 
         if work.output_dataset_name and work.output_file_name:
-            output_dataset_name = work.output_dataset_name.replace("$WORKFLOWID", work.request_id)
+            output_dataset_name = work.output_dataset_name.replace("$WORKFLOWID", str(work.request_id))
             output_dataset_name_no_scope = work.output_dataset_name.split(":")[-1]
             output_file_name = f"{output_dataset_name_no_scope[:-1]}_${{SN/P}}.{work.output_file_name}"
             tmp_dict = {"dataset": output_dataset_name,

--- a/main/lib/idds/agents/carrier/poller.py
+++ b/main/lib/idds/agents/carrier/poller.py
@@ -238,7 +238,7 @@ class Poller(BaseAgent):
                                                                      processing['transform_id'],
                                                                      processing['processing_id'])
 
-    def update_processing(self, processing, processing_model, use_bulk_update_mappings=True):
+    def update_processing(self, processing, processing_model, use_bulk_update_mappings=True, renew_updated_at=False):
         try:
             if processing:
                 log_prefix = self.get_log_prefix(processing_model)
@@ -247,7 +247,8 @@ class Poller(BaseAgent):
 
                 processing['update_processing']['parameters']['locking'] = ProcessingLocking.Idle
                 # self.logger.debug("wen: %s" % str(processing))
-                processing['update_processing']['parameters']['updated_at'] = datetime.datetime.utcnow()
+                if renew_updated_at:
+                    processing['update_processing']['parameters']['updated_at'] = datetime.datetime.utcnow()
                 # check update_processing status
                 if 'status' in processing['update_processing']['parameters']:
                     new_status = processing['update_processing']['parameters']['status']
@@ -556,7 +557,7 @@ class Poller(BaseAgent):
                                          'parameters': parameters}
                     ret = {'update_processing': update_processing,
                            'update_contents': []}
-                    self.update_processing(ret, pr)
+                    self.update_processing(ret, pr, renew_updated_at=True)
                     pro_ret = ReturnCode.Ok.value
                 else:
                     log_pre = self.get_log_prefix(pr)
@@ -568,7 +569,7 @@ class Poller(BaseAgent):
                         ret = self.handle_update_processing(pr)
                     # self.logger.info(log_pre + "process_update_processing result: %s" % str(ret))
 
-                    self.update_processing(ret, pr)
+                    self.update_processing(ret, pr, renew_updated_at=True)
 
                     if 'processing_status' in ret and ret['processing_status'] == ProcessingStatus.Triggering:
                         event_content = {}

--- a/main/lib/idds/tests/panda_test.py
+++ b/main/lib/idds/tests/panda_test.py
@@ -94,7 +94,8 @@ task_ids = [3906, 4266, 4267, 4357, 4358, 4414, 4416, 4417, 4418]
 task_ids = [4559, 4558, 4725, 4727, 4732, 4734, 4737, 4741]
 task_ids = [i for i in range(7178, 7512)]
 task_ids = [i for i in range(7512, 7560)]
-task_ids = [i for i in range(7686, 7710)]
+task_ids = [i for i in range(7979, 8140)]
+task_ids = [i for i in range(8163, 8185)]
 for task_id in task_ids:
     print("Killing %s" % task_id)
     ret = Client.killTask(task_id, verbose=True)

--- a/main/lib/idds/tests/panda_test.py
+++ b/main/lib/idds/tests/panda_test.py
@@ -96,6 +96,7 @@ task_ids = [i for i in range(7178, 7512)]
 task_ids = [i for i in range(7512, 7560)]
 task_ids = [i for i in range(7979, 8140)]
 task_ids = [i for i in range(8163, 8185)]
+task_ids = [i for i in range(8279, 8287)]
 for task_id in task_ids:
     print("Killing %s" % task_id)
     ret = Client.killTask(task_id, verbose=True)

--- a/main/tools/env/setup_panda.sh
+++ b/main/tools/env/setup_panda.sh
@@ -53,6 +53,11 @@ elif [ "$instance" == "bnl" ]; then
     unset IDDS_HOST
     # doma
     # export IDDS_HOST=https://aipanda105.cern.ch:443/idds
+
+    # bnl rucio
+    source /cvmfs/eic.opensciencegrid.org/rucio-clients/alrb_setup.sh
+    voms-proxy-init
+
 elif [ "$instance" == "usdf_dev" ]; then
     export PANDA_AUTH=oidc
     export PANDA_BEHIND_REAL_LB=true

--- a/main/tools/env/setup_panda.sh
+++ b/main/tools/env/setup_panda.sh
@@ -57,6 +57,7 @@ elif [ "$instance" == "bnl" ]; then
     # bnl rucio
     source /cvmfs/eic.opensciencegrid.org/rucio-clients/alrb_setup.sh
     voms-proxy-init
+    export RUCIO_ACCOUNT=wguan
 
 elif [ "$instance" == "usdf_dev" ]; then
     export PANDA_AUTH=oidc

--- a/monitor/data/conf.js
+++ b/monitor/data/conf.js
@@ -1,9 +1,9 @@
 
 var appConfig = {
-    'iddsAPI_request': "https://lxplus972.cern.ch:443/idds/monitor_request/null/null",
-    'iddsAPI_transform': "https://lxplus972.cern.ch:443/idds/monitor_transform/null/null",
-    'iddsAPI_processing': "https://lxplus972.cern.ch:443/idds/monitor_processing/null/null",
-    'iddsAPI_request_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/true/false/false",
-    'iddsAPI_transform_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/true/false",
-    'iddsAPI_processing_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/false/true"
+    'iddsAPI_request': "https://lxplus901.cern.ch:443/idds/monitor_request/null/null",
+    'iddsAPI_transform': "https://lxplus901.cern.ch:443/idds/monitor_transform/null/null",
+    'iddsAPI_processing': "https://lxplus901.cern.ch:443/idds/monitor_processing/null/null",
+    'iddsAPI_request_detail': "https://lxplus901.cern.ch:443/idds/monitor/null/null/true/false/false",
+    'iddsAPI_transform_detail': "https://lxplus901.cern.ch:443/idds/monitor/null/null/false/true/false",
+    'iddsAPI_processing_detail': "https://lxplus901.cern.ch:443/idds/monitor/null/null/false/false/true"
 }

--- a/monitor/data/conf.js
+++ b/monitor/data/conf.js
@@ -1,9 +1,9 @@
 
 var appConfig = {
-    'iddsAPI_request': "https://lxplus953.cern.ch:443/idds/monitor_request/null/null",
-    'iddsAPI_transform': "https://lxplus953.cern.ch:443/idds/monitor_transform/null/null",
-    'iddsAPI_processing': "https://lxplus953.cern.ch:443/idds/monitor_processing/null/null",
-    'iddsAPI_request_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/true/false/false",
-    'iddsAPI_transform_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/false/true/false",
-    'iddsAPI_processing_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/false/false/true"
+    'iddsAPI_request': "https://lxplus972.cern.ch:443/idds/monitor_request/null/null",
+    'iddsAPI_transform': "https://lxplus972.cern.ch:443/idds/monitor_transform/null/null",
+    'iddsAPI_processing': "https://lxplus972.cern.ch:443/idds/monitor_processing/null/null",
+    'iddsAPI_request_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/true/false/false",
+    'iddsAPI_transform_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/true/false",
+    'iddsAPI_processing_detail': "https://lxplus972.cern.ch:443/idds/monitor/null/null/false/false/true"
 }

--- a/monitor/data/conf.js
+++ b/monitor/data/conf.js
@@ -1,9 +1,9 @@
 
 var appConfig = {
-    'iddsAPI_request': "https://lxplus937.cern.ch:443/idds/monitor_request/null/null",
-    'iddsAPI_transform': "https://lxplus937.cern.ch:443/idds/monitor_transform/null/null",
-    'iddsAPI_processing': "https://lxplus937.cern.ch:443/idds/monitor_processing/null/null",
-    'iddsAPI_request_detail': "https://lxplus937.cern.ch:443/idds/monitor/null/null/true/false/false",
-    'iddsAPI_transform_detail': "https://lxplus937.cern.ch:443/idds/monitor/null/null/false/true/false",
-    'iddsAPI_processing_detail': "https://lxplus937.cern.ch:443/idds/monitor/null/null/false/false/true"
+    'iddsAPI_request': "https://lxplus953.cern.ch:443/idds/monitor_request/null/null",
+    'iddsAPI_transform': "https://lxplus953.cern.ch:443/idds/monitor_transform/null/null",
+    'iddsAPI_processing': "https://lxplus953.cern.ch:443/idds/monitor_processing/null/null",
+    'iddsAPI_request_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/true/false/false",
+    'iddsAPI_transform_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/false/true/false",
+    'iddsAPI_processing_detail': "https://lxplus953.cern.ch:443/idds/monitor/null/null/false/false/true"
 }

--- a/workflow/bin/idds_parse_workflow_args
+++ b/workflow/bin/idds_parse_workflow_args
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0OA
+#
+# Authors:
+# - Wen Guan, <wen.guan@cern.ch>, 2024 - 2025
+
+
+"""
+Run workflow.
+"""
+
+from __future__ import print_function
+
+import argparse
+import base64
+import logging
+import json
+import os
+import sys
+import time
+import traceback
+
+
+logging.basicConfig(stream=sys.stderr,
+                    level=logging.DEBUG,
+                    format='%(asctime)s\t%(threadName)s\t%(name)s\t%(levelname)s\t%(message)s')
+logging.Formatter.converter = time.gmtime
+
+
+def get_parser(program):
+    """
+    Return the argparse parser.
+    """
+    oparser = argparse.ArgumentParser(prog=os.path.basename(program), add_help=True)
+
+    # common items
+    oparser.add_argument('--pre_setup', dest='pre_setup', help="The pre_setup.")
+    oparser.add_argument('--setup', dest='setup', help="The setup.")
+    oparser.add_argument('--output_map', dest='output_map', help="The output map.")
+    oparser.add_argument('--inputs', dest='inputs', help="The input list.")
+    oparser.add_argument('run_args', nargs=argparse.REMAINDER, help="All other arguments")
+    return oparser
+
+
+def get_workflow_setup_script():
+    script = """#!/bin/bash
+
+echo "current dir: " $PWD
+
+which python
+which python3
+
+# cd ${current_dir}
+
+# if it's in a container, this part is needed again to setup the environment.
+current_dir=$PWD
+export PATH=${current_dir}:${current_dir}/tmp_bin:${current_dir}/bin:$PATH
+export PYTHONPATH=${current_dir}:${current_dir}/lib_py:$PYTHONPATH
+
+if ! command -v python &> /dev/null
+then
+    echo "no python, link python3 to python"
+    # alias python=python3
+    ln -fs $(which python3) ./python
+fi
+
+if [ -f ${current_dir}/x509_proxy ]; then
+    export X509_USER_PROXY=${current_dir}/x509_proxy
+fi
+"""
+    return script
+
+
+# This part is possbile to run on SL7 with python2
+def decode_base64(sb, remove_quotes=False):
+    try:
+        if isinstance(sb, str):
+            if sys.version_info.major == 2:
+                # In python 2, str is already bytes
+                sb_bytes = sb
+            else:
+                sb_bytes = bytes(sb, 'ascii')
+        elif isinstance(sb, bytes):
+            sb_bytes = sb
+        else:
+            return sb
+        decode_str = base64.b64decode(sb_bytes).decode("utf-8")
+        # remove the single quotes afeter decoding
+        if remove_quotes:
+            return decode_str[1:-1]
+        return decode_str
+    except Exception as ex:
+        logging.error("decode_base64 %s: %s" % (sb, ex))
+        return sb
+
+
+def create_run_workflow_cmd(run_args):
+    # current_dir = os.getcwd()
+    run_script = "./run_workflow.sh"
+    # cmd = os.path.join(current_dir, run_script)
+    setup_script = get_workflow_setup_script()
+    # script = setup_script + "\n" + " ".join(run_args)
+    script = setup_script + "\n"
+    script += " ".join(f'"{str(arg)}"' for arg in run_args)
+
+    logging.debug("script: ")
+    logging.debug(script)
+
+    with open(run_script, 'w') as f:
+        f.write(script)
+    os.chmod(run_script, 0o755)
+    return run_script
+
+
+def process_args(args):
+    logging.debug("pre_setup:")
+    logging.debug(args.pre_setup)
+    logging.debug("setup: ")
+    logging.debug(args.setup)
+    logging.debug("output_map: ")
+    logging.debug(args.output_map)
+    logging.debug("inputs: ")
+    logging.debug(args.inputs)
+    logging.debug("run_args:")
+    logging.debug(args.run_args)
+
+    cmd = ""
+    if args.pre_setup:
+        pre_setup = json.loads(decode_base64(args.pre_setup, remove_quotes=False))
+        if pre_setup:
+            cmd = cmd + pre_setup
+    if args.setup:
+        setup = json.loads(decode_base64(args.setup, remove_quotes=False))
+        if setup:
+            cmd = cmd + " " + setup
+
+    run_script = create_run_workflow_cmd(args.run_args)
+
+    cmd = cmd + " " + run_script
+    return cmd
+
+
+if __name__ == '__main__':
+    arguments = sys.argv[1:]
+
+    oparser = get_parser(sys.argv[0])
+    # argcomplete.autocomplete(oparser)
+
+    # logging.debug("all args:")
+    # logging.debug(sys.argv)
+    logging.debug("arguments: ")
+    logging.debug(arguments)
+    args = oparser.parse_args(arguments)
+
+    try:
+        start_time = time.time()
+        new_command = process_args(args)
+        print(new_command)
+        end_time = time.time()
+        logging.info("Completed processing args in %-0.4f sec." % (end_time - start_time))
+        sys.exit(0)
+    except Exception as error:
+        logging.error("Strange error: {0}".format(error))
+        logging.error(traceback.format_exc())
+        sys.exit(-1)

--- a/workflow/bin/idds_parse_workflow_args
+++ b/workflow/bin/idds_parse_workflow_args
@@ -40,8 +40,9 @@ def get_parser(program):
     # common items
     oparser.add_argument('--pre_setup', dest='pre_setup', help="The pre_setup.")
     oparser.add_argument('--setup', dest='setup', help="The setup.")
-    oparser.add_argument('--output_map', dest='output_map', help="The output map.")
-    oparser.add_argument('--inputs', dest='inputs', help="The input list.")
+    # oparser.add_argument('--output_map', dest='output_map', help="The output map.")
+    # oparser.add_argument('--inputs', dest='inputs', help="The input list.")
+    # oparser.add_argument('--input_map', dest='input_map', help="The input map.")
     oparser.add_argument('run_args', nargs=argparse.REMAINDER, help="All other arguments")
     return oparser
 
@@ -121,10 +122,10 @@ def process_args(args):
     logging.debug(args.pre_setup)
     logging.debug("setup: ")
     logging.debug(args.setup)
-    logging.debug("output_map: ")
-    logging.debug(args.output_map)
-    logging.debug("inputs: ")
-    logging.debug(args.inputs)
+    # logging.debug("output_map: ")
+    # logging.debug(args.output_map)
+    # logging.debug("inputs: ")
+    # logging.debug(args.inputs)
     logging.debug("run_args:")
     logging.debug(args.run_args)
 

--- a/workflow/bin/run_workflow
+++ b/workflow/bin/run_workflow
@@ -22,11 +22,14 @@ import base64
 import json
 import logging
 import pickle
+import re
 import os
 import sys
 import time
 import traceback
 import zlib
+
+from collections import defaultdict
 
 from idds.common.utils import json_dumps, json_loads, setup_logging, decode_base64
 # from idds.common.utils import merge_dict
@@ -119,7 +122,7 @@ def run_workflow(name, context, original_args, current_job_kwargs, output_map, i
     return 0
 
 
-def run_work(name, context, original_args, current_job_kwargs, output_map, inputs, input_map):
+def run_work(name, context, original_args, current_job_kwargs, output_map, inputs, input_map, inputs_group):
     context, func_name, pre_kwargs, args, kwargs, multi_jobs_kwargs_list, current_job_kwargs = get_context_args(context, original_args, current_job_kwargs)
     logging.info("name: %s" % name)
     logging.info("context: %s" % context)
@@ -131,13 +134,12 @@ def run_work(name, context, original_args, current_job_kwargs, output_map, input
     logging.info("current_job_kwargs: %s" % str(current_job_kwargs))
     logging.info(f"output_map: {output_map}")
     logging.info(f"inputs: {inputs}")
-    logging.info(f"input_map: {input_map}")
 
     context.initialize()
     context.setup_source_files()
 
     work = Work(func=func_name, pre_kwargs=pre_kwargs, args=args, kwargs=kwargs, multi_jobs_kwargs_list=multi_jobs_kwargs_list,
-                current_job_kwargs=current_job_kwargs, context=context, name=name, inputs=inputs, input_map=input_map)
+                current_job_kwargs=current_job_kwargs, context=context, name=name, inputs=inputs, input_map=input_map, inputs_group=inputs_group)
     work.load()
     logging.info("work: %s" % work)
     ret = work.run()
@@ -148,7 +150,7 @@ def run_work(name, context, original_args, current_job_kwargs, output_map, input
     return 0
 
 
-def run_iworkflow(args):
+def run_iworkflow(args, inputs_group):
     if args.context:
         context = decode_base64(args.context)
         context = json_loads(context)
@@ -224,7 +226,10 @@ def run_iworkflow(args):
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
         logging.info("current_job_kwargs: %s" % current_job_kwargs)
-        exit_code = run_workflow(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map)
+        logging.info(f"inputs: {args.inputs}")
+        logging.info(f"input_map: {args.input_map}")
+        logging.info(f"inputs_group: {inputs_group}")
+        exit_code = run_workflow(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map, inputs_group)
         logging.info("exit code: %s" % exit_code)
     else:
         logging.info("run work")
@@ -234,7 +239,10 @@ def run_iworkflow(args):
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
         logging.info("current_job_kwargs: %s" % current_job_kwargs)
-        exit_code = run_work(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map)
+        logging.info(f"inputs: {args.inputs}")
+        logging.info(f"input_map: {args.input_map}")
+        logging.info(f"inputs_group: {inputs_group}")
+        exit_code = run_work(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map, inputs_group)
         logging.info("exit code: %s" % exit_code)
     return exit_code
 
@@ -250,6 +258,28 @@ def custom_action():
             print(values)
             # setattr(namespace, self.dest, values)
     return CustomAction
+
+
+def parse_unknown_grouped_args(args):
+    groups = defaultdict(lambda: {'inputs': [], 'input_map': None})
+    pattern = re.compile(r"--(inputs|input_map)(\d+)")
+    i = 0
+    while i < len(args):
+        match = pattern.match(args[i])
+        if match:
+            key, group_id = match.group(1), int(match.group(2))
+            i += 1
+            if i < len(args) and not args[i].startswith('--'):
+                groups[group_id][key] = args[i]
+                i += 1
+        else:
+            i += 1
+    # Convert dict
+    return {
+        group['input_map']: group['inputs']
+        for group in (groups[i] for i in sorted(groups.keys()))
+        if group['input_map'] is not None
+    }
 
 
 def get_parser():
@@ -289,7 +319,10 @@ if __name__ == '__main__':
             logging.getLogger().setLevel(logging.DEBUG)
         start_time = time.time()
 
-        exit_code = run_iworkflow(args)
+        # Parse dynamic grouped arguments
+        inputs_group = parse_unknown_grouped_args(unknown)
+
+        exit_code = run_iworkflow(args, inputs_group)
         end_time = time.time()
         if args.verbose:
             print("Completed in %-0.4f sec." % (end_time - start_time))

--- a/workflow/bin/run_workflow
+++ b/workflow/bin/run_workflow
@@ -58,6 +58,9 @@ def get_context_args(context, original_args, current_job_kwargs):
             logging.info("current_job_kwargs == original ${IN/L}, is not set")
         else:
             try:
+                # if type(current_job_kwargs) not in (list, tuple):
+                #     current_job_kwargs = ast.literal_eval(current_job_kwargs)
+
                 current_job_kwargs = json_loads(current_job_kwargs)
 
                 if current_job_kwargs:
@@ -88,7 +91,7 @@ def map_output_files(output_map):
             logging.warning(f"cannot link {org_file} to {mapped_file}, because it doesn't exist")
 
 
-def run_workflow(name, context, original_args, current_job_kwargs, output_map):
+def run_workflow(name, context, original_args, current_job_kwargs, output_map, inputs, input_map):
     context, func_name, pre_kwargs, args, kwargs, multi_jobs_kwargs_list, current_job_kwargs = get_context_args(context, original_args, current_job_kwargs)
     logging.info("name: %s" % name)
     logging.info("context: %s" % context)
@@ -99,6 +102,8 @@ def run_workflow(name, context, original_args, current_job_kwargs, output_map):
     logging.info("multi_jobs_kwargs_list: %s" % str(multi_jobs_kwargs_list))
     logging.info("current_job_kwargs: %s" % str(current_job_kwargs))
     logging.info(f"output_map: {output_map}")
+    logging.info(f"inputs: {inputs}")
+    logging.info(f"input_map: {input_map}")
 
     context.initialize()
     context.setup_source_files()
@@ -114,7 +119,7 @@ def run_workflow(name, context, original_args, current_job_kwargs, output_map):
     return 0
 
 
-def run_work(name, context, original_args, current_job_kwargs, output_map):
+def run_work(name, context, original_args, current_job_kwargs, output_map, inputs, input_map):
     context, func_name, pre_kwargs, args, kwargs, multi_jobs_kwargs_list, current_job_kwargs = get_context_args(context, original_args, current_job_kwargs)
     logging.info("name: %s" % name)
     logging.info("context: %s" % context)
@@ -125,11 +130,14 @@ def run_work(name, context, original_args, current_job_kwargs, output_map):
     logging.info("multi_jobs_kwargs_list: %s" % str(multi_jobs_kwargs_list))
     logging.info("current_job_kwargs: %s" % str(current_job_kwargs))
     logging.info(f"output_map: {output_map}")
+    logging.info(f"inputs: {inputs}")
+    logging.info(f"input_map: {input_map}")
 
     context.initialize()
     context.setup_source_files()
 
-    work = Work(func=func_name, pre_kwargs=pre_kwargs, args=args, kwargs=kwargs, multi_jobs_kwargs_list=multi_jobs_kwargs_list, current_job_kwargs=current_job_kwargs, context=context, name=name)
+    work = Work(func=func_name, pre_kwargs=pre_kwargs, args=args, kwargs=kwargs, multi_jobs_kwargs_list=multi_jobs_kwargs_list,
+                current_job_kwargs=current_job_kwargs, context=context, name=name, inputs=inputs, input_map=input_map)
     work.load()
     logging.info("work: %s" % work)
     ret = work.run()
@@ -188,6 +196,26 @@ def run_iworkflow(args):
         except Exception as ex:
             logging.warning(f"failed to load args.output_map with json: {ex}")
 
+    if args.inputs:
+        try:
+            args.inputs = ast.literal_eval(args.inputs)
+        except Exception as ex:
+            logging.warning(f"failed to load args.inputs with ast: {ex}")
+        try:
+            args.inputs = json.loads(args.inputs)
+        except Exception as ex:
+            logging.warning(f"failed to load args.inputs with json: {ex}")
+
+    if args.input_map:
+        try:
+            args.input_map = ast.literal_eval(args.input_map)
+        except Exception as ex:
+            logging.warning(f"failed to load args.input_map with ast: {ex}")
+        try:
+            args.input_map = json.loads(args.input_map)
+        except Exception as ex:
+            logging.warning(f"failed to load args.input_map with json: {ex}")
+
     if args.type == 'workflow':
         logging.info("run workflow")
         password = context.broker_password
@@ -196,7 +224,7 @@ def run_iworkflow(args):
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
         logging.info("current_job_kwargs: %s" % current_job_kwargs)
-        exit_code = run_workflow(args.name, context, original_args, current_job_kwargs, args.output_map)
+        exit_code = run_workflow(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map)
         logging.info("exit code: %s" % exit_code)
     else:
         logging.info("run work")
@@ -206,7 +234,7 @@ def run_iworkflow(args):
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
         logging.info("current_job_kwargs: %s" % current_job_kwargs)
-        exit_code = run_work(args.name, context, original_args, current_job_kwargs, args.output_map)
+        exit_code = run_work(args.name, context, original_args, current_job_kwargs, args.output_map, args.inputs, args.input_map)
         logging.info("exit code: %s" % exit_code)
     return exit_code
 
@@ -242,6 +270,8 @@ def get_parser():
     oparser.add_argument('--output', dest='output', help="The output file name.")
     oparser.add_argument('--mapped_output', dest='output', help="The output file name to be mapped.")
     oparser.add_argument('--output_map', dest='output_map', help="The output map.")
+    oparser.add_argument('--inputs', dest='inputs', help="The input list.")
+    oparser.add_argument('--input_map', dest='input_map', help="The input map.")
     oparser.add_argument('--others', dest='others', nargs='*', help="Additional custom arguments (e.g., key=value).")
     return oparser
 

--- a/workflow/bin/run_workflow
+++ b/workflow/bin/run_workflow
@@ -73,13 +73,19 @@ def get_context_args(context, original_args, current_job_kwargs):
 
 
 def map_output_files(output_map):
-    if output_map:
-        for org_file, mapped_file in output_map:
-            if os.path.exists(org_file):
+    if not output_map:
+        logging.info("No output mapping provided.")
+        return
+
+    for org_file, mapped_file in output_map.items():
+        if os.path.exists(org_file):
+            try:
                 os.symlink(org_file, mapped_file)
                 logging.info(f"link {org_file} to {mapped_file}")
-            else:
-                logging.info(f"cannot link {org_file} to {mapped_file}, because it doesn't exist")
+            except Exception as e:
+                logging.error(f"Failed to link {org_file} to {mapped_file}: {e}")
+        else:
+            logging.warning(f"cannot link {org_file} to {mapped_file}, because it doesn't exist")
 
 
 def run_workflow(name, context, original_args, current_job_kwargs, output_map):
@@ -128,6 +134,7 @@ def run_work(name, context, original_args, current_job_kwargs, output_map):
     logging.info("work: %s" % work)
     ret = work.run()
     logging.info("run work result: %s" % str(ret))
+    map_output_files(output_map)
     if not ret:
         return -1
     return 0

--- a/workflow/bin/run_workflow
+++ b/workflow/bin/run_workflow
@@ -225,7 +225,7 @@ def run_iworkflow(args, inputs_group):
         logging.info("context: %s" % json_dumps(context))
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
-        logging.info("current_job_kwargs: %s" % current_job_kwargs)
+        logging.info(f"current_job_kwargs: {type(current_job_kwargs)},{current_job_kwargs}")
         logging.info(f"inputs: {args.inputs}")
         logging.info(f"input_map: {args.input_map}")
         logging.info(f"inputs_group: {inputs_group}")
@@ -238,7 +238,7 @@ def run_iworkflow(args, inputs_group):
         logging.info("context: %s" % json_dumps(context))
         context.broker_password = password
         logging.info("original_args: %s" % original_args)
-        logging.info("current_job_kwargs: %s" % current_job_kwargs)
+        logging.info(f"current_job_kwargs: {type(current_job_kwargs)},{current_job_kwargs}")
         logging.info(f"inputs: {args.inputs}")
         logging.info(f"input_map: {args.input_map}")
         logging.info(f"inputs_group: {inputs_group}")
@@ -260,6 +260,19 @@ def custom_action():
     return CustomAction
 
 
+def parse_item(name, value):
+    try:
+        ret = value
+        ret = ast.literal_eval(ret)
+    except Exception as ex:
+        logging.warning(f"failed to load {name}: {ret} with ast: {ex}")
+    try:
+        ret = json.loads(ret)
+    except Exception as ex:
+        logging.warning(f"failed to load {name}: {ret} with json: {ex}")
+    return ret
+
+
 def parse_unknown_grouped_args(args):
     groups = defaultdict(lambda: {'inputs': [], 'input_map': None})
     pattern = re.compile(r"--(inputs|input_map)(\d+)")
@@ -275,11 +288,12 @@ def parse_unknown_grouped_args(args):
         else:
             i += 1
     # Convert dict
-    return {
-        group['input_map']: group['inputs']
-        for group in (groups[i] for i in sorted(groups.keys()))
-        if group['input_map'] is not None
-    }
+    rets = {}
+    for group in (groups[i] for i in sorted(groups.keys())):
+        if group['input_map'] is not None:
+            inputs = parse_item('inputs', group['inputs'])
+            rets[group['input_map']] = inputs
+    return rets
 
 
 def get_parser():

--- a/workflow/lib/idds/iworkflow/work.py
+++ b/workflow/lib/idds/iworkflow/work.py
@@ -402,7 +402,7 @@ class Work(Base):
                  current_job_kwargs=None, map_results=False, source_dir=None, init_env=None, is_unique_func_name=False, name=None,
                  parent_workload_id=None, no_wait_parent=False, container_options=None, input_datasets=None, output_file_name=None,
                  output_dataset_name=None, num_events=None, num_events_per_job=None, parent_transform_id=None, parent_internal_id=None,
-                 log_dataset_name=None, inputs=None, input_map=None, enable_separate_log=False):
+                 log_dataset_name=None, inputs=None, input_map=None, inputs_group=None, enable_separate_log=False):
         """
         Init a workflow.
         """
@@ -454,6 +454,7 @@ class Work(Base):
                                  'parent_internal_id': parent_internal_id}
         self.inputs = inputs
         self.input_map = input_map
+        self.inputs_group = inputs_group
 
     @property
     def logger(self):
@@ -1205,6 +1206,12 @@ class Work(Base):
 
             if self.inputs and self.input_map:
                 new_kwargs = {self.input_map: ",".join[self.inputs]}
+                kwargs_copy.update(new_kwargs)
+            if self.inputs_group:
+                new_kwargs = {
+                    k: ",".join(v) if isinstance(v, (list, tuple)) else str(v)
+                    for k, v in self.inputs_group.items()
+                }
                 kwargs_copy.update(new_kwargs)
 
             ret_status, ret_output, ret_err = self.run_func(self._func, pre_kwargs_copy, args_copy, kwargs_copy)

--- a/workflow/lib/idds/iworkflow/work.py
+++ b/workflow/lib/idds/iworkflow/work.py
@@ -402,7 +402,7 @@ class Work(Base):
                  current_job_kwargs=None, map_results=False, source_dir=None, init_env=None, is_unique_func_name=False, name=None,
                  parent_workload_id=None, no_wait_parent=False, container_options=None, input_dataset_name=None, output_file_name=None,
                  output_dataset_name=None, num_events=None, num_events_per_job=None, parent_transform_id=None, parent_internal_id=None,
-                 enable_separate_log=False):
+                 log_dataset_name=None, enable_separate_log=False):
         """
         Init a workflow.
         """
@@ -447,6 +447,7 @@ class Work(Base):
         self.other_attributes = {'input_dataset_name': input_dataset_name,
                                  'output_file_name': output_file_name,
                                  'output_dataset_name': output_dataset_name,
+                                 'log_dataset_name': log_dataset_name,
                                  'num_events': num_events,
                                  'num_events_per_job': num_events_per_job,
                                  'parent_transform_id': parent_transform_id,
@@ -760,6 +761,14 @@ class Work(Base):
     @output_dataset_name.setter
     def output_dataset_name(self, value):
         self.set_other_attribute('output_dataset_name', value)
+
+    @property
+    def log_dataset_name(self):
+        return self.get_other_attribute('log_dataset_name')
+
+    @log_dataset_name.setter
+    def log_dataset_name(self, value):
+        self.set_other_attribute('log_dataset_name', value)
 
     @property
     def num_events(self):
@@ -1312,12 +1321,14 @@ def run_work_distributed(w):
 # foo = work(arg)(foo)
 def work(func=None, *, workflow=None, pre_kwargs={}, name=None, return_work=False, map_results=False, lazy=False, init_env=None, no_wraps=False,
          container_options=None, parent_workload_id=None, no_wait_parent=False, input_dataset_name=None, output_file_name=None,
-         enable_separate_log=False, output_dataset_name=None, num_events=None, num_events_per_job=None, parent_transform_id=None, parent_internal_id=None):
+         enable_separate_log=False, output_dataset_name=None, log_dataset_name=None, num_events=None, num_events_per_job=None,
+         parent_transform_id=None, parent_internal_id=None):
     if func is None:
         return functools.partial(work, workflow=workflow, pre_kwargs=pre_kwargs, return_work=return_work, no_wraps=no_wraps,
                                  name=name, map_results=map_results, lazy=lazy, init_env=init_env, container_options=container_options,
                                  parent_workload_id=parent_workload_id, no_wait_parent=no_wait_parent, parent_transform_id=parent_transform_id,
                                  input_dataset_name=input_dataset_name, output_file_name=output_file_name, output_dataset_name=output_dataset_name,
+                                 log_dataset_name=log_dataset_name,
                                  enable_separate_log=enable_separate_log, num_events=num_events, num_events_per_job=num_events_per_job,
                                  parent_internal_id=parent_internal_id)
 
@@ -1340,7 +1351,7 @@ def work(func=None, *, workflow=None, pre_kwargs={}, name=None, return_work=Fals
                          container_options=container_options, parent_workload_id=parent_workload_id, no_wait_parent=no_wait_parent,
                          parent_transform_id=parent_transform_id, input_dataset_name=input_dataset_name, output_file_name=output_file_name,
                          output_dataset_name=output_dataset_name, num_events=num_events, num_events_per_job=num_events_per_job,
-                         parent_internal_id=parent_internal_id, enable_separate_log=enable_separate_log)
+                         parent_internal_id=parent_internal_id, enable_separate_log=enable_separate_log, log_dataset_name=log_dataset_name)
                 # if distributed:
 
                 if return_work:

--- a/workflow/lib/idds/iworkflow/work.py
+++ b/workflow/lib/idds/iworkflow/work.py
@@ -400,9 +400,9 @@ class Work(Base):
 
     def __init__(self, func=None, workflow_context=None, context=None, pre_kwargs=None, args=None, kwargs=None, multi_jobs_kwargs_list=None,
                  current_job_kwargs=None, map_results=False, source_dir=None, init_env=None, is_unique_func_name=False, name=None,
-                 parent_workload_id=None, no_wait_parent=False, container_options=None, input_dataset_name=None, output_file_name=None,
+                 parent_workload_id=None, no_wait_parent=False, container_options=None, input_datasets=None, output_file_name=None,
                  output_dataset_name=None, num_events=None, num_events_per_job=None, parent_transform_id=None, parent_internal_id=None,
-                 log_dataset_name=None, enable_separate_log=False):
+                 log_dataset_name=None, inputs=None, input_map=None, enable_separate_log=False):
         """
         Init a workflow.
         """
@@ -444,7 +444,7 @@ class Work(Base):
         self.parent_workload_id = parent_workload_id
         self.no_wait_parent = no_wait_parent
 
-        self.other_attributes = {'input_dataset_name': input_dataset_name,
+        self.other_attributes = {'input_datasets': input_datasets,
                                  'output_file_name': output_file_name,
                                  'output_dataset_name': output_dataset_name,
                                  'log_dataset_name': log_dataset_name,
@@ -452,6 +452,8 @@ class Work(Base):
                                  'num_events_per_job': num_events_per_job,
                                  'parent_transform_id': parent_transform_id,
                                  'parent_internal_id': parent_internal_id}
+        self.inputs = inputs
+        self.input_map = input_map
 
     @property
     def logger(self):
@@ -739,12 +741,12 @@ class Work(Base):
         return self.get_other_attribute('parent_internal_id')
 
     @property
-    def input_dataset_name(self):
-        return self.get_other_attribute('input_dataset_name')
+    def input_datasets(self):
+        return self.get_other_attribute('input_datasets')
 
-    @input_dataset_name.setter
-    def input_dataset_name(self, value):
-        self.set_other_attribute('input_dataset_name', value)
+    @input_datasets.setter
+    def input_datasets(self, value):
+        self.set_other_attribute('input_datasets', value)
 
     @property
     def output_file_name(self):
@@ -1201,6 +1203,10 @@ class Work(Base):
             elif current_job_kwargs and type(current_job_kwargs) in [tuple, list]:
                 args_copy = copy.deepcopy(current_job_kwargs)
 
+            if self.inputs and self.input_map:
+                new_kwargs = {self.input_map: ",".join[self.inputs]}
+                kwargs_copy.update(new_kwargs)
+
             ret_status, ret_output, ret_err = self.run_func(self._func, pre_kwargs_copy, args_copy, kwargs_copy)
 
             request_id = self._context.request_id
@@ -1258,7 +1264,7 @@ class Work(Base):
         cmd = "run_workflow --type work --name %s " % self.name
         cmd += "--context %s --original_args %s " % (encode_base64(json_dumps(self._context)),
                                                      encode_base64(json_dumps(self._func_name_and_args)))
-        cmd += "--current_job_kwargs ${IN/L}"
+        cmd += '--current_job_kwargs "${IN/T}"'
         return cmd
 
     def get_run_args_to_file_cmd(self):
@@ -1266,7 +1272,7 @@ class Work(Base):
                 'name': self.name,
                 'context': self._context,
                 'original_args': self._func_name_and_args,
-                'current_job_kwargs': '${IN/L}'}
+                'current_job_kwargs': '"${IN/T}"'}
         args_json = encode_base64(json_dumps(args))
         cmd = 'echo ' + args_json + ' > run_workflow_args; '
         return cmd
@@ -1320,14 +1326,14 @@ def run_work_distributed(w):
 
 # foo = work(arg)(foo)
 def work(func=None, *, workflow=None, pre_kwargs={}, name=None, return_work=False, map_results=False, lazy=False, init_env=None, no_wraps=False,
-         container_options=None, parent_workload_id=None, no_wait_parent=False, input_dataset_name=None, output_file_name=None,
+         container_options=None, parent_workload_id=None, no_wait_parent=False, input_datasets=None, output_file_name=None,
          enable_separate_log=False, output_dataset_name=None, log_dataset_name=None, num_events=None, num_events_per_job=None,
          parent_transform_id=None, parent_internal_id=None):
     if func is None:
         return functools.partial(work, workflow=workflow, pre_kwargs=pre_kwargs, return_work=return_work, no_wraps=no_wraps,
                                  name=name, map_results=map_results, lazy=lazy, init_env=init_env, container_options=container_options,
                                  parent_workload_id=parent_workload_id, no_wait_parent=no_wait_parent, parent_transform_id=parent_transform_id,
-                                 input_dataset_name=input_dataset_name, output_file_name=output_file_name, output_dataset_name=output_dataset_name,
+                                 input_datasets=input_datasets, output_file_name=output_file_name, output_dataset_name=output_dataset_name,
                                  log_dataset_name=log_dataset_name,
                                  enable_separate_log=enable_separate_log, num_events=num_events, num_events_per_job=num_events_per_job,
                                  parent_internal_id=parent_internal_id)
@@ -1349,7 +1355,7 @@ def work(func=None, *, workflow=None, pre_kwargs={}, name=None, return_work=Fals
                 w = Work(workflow_context=workflow_context, func=func, pre_kwargs=pre_kwargs, args=args, kwargs=kwargs,
                          name=name, multi_jobs_kwargs_list=multi_jobs_kwargs_list, map_results=map_results, init_env=init_env,
                          container_options=container_options, parent_workload_id=parent_workload_id, no_wait_parent=no_wait_parent,
-                         parent_transform_id=parent_transform_id, input_dataset_name=input_dataset_name, output_file_name=output_file_name,
+                         parent_transform_id=parent_transform_id, input_datasets=input_datasets, output_file_name=output_file_name,
                          output_dataset_name=output_dataset_name, num_events=num_events, num_events_per_job=num_events_per_job,
                          parent_internal_id=parent_internal_id, enable_separate_log=enable_separate_log, log_dataset_name=log_dataset_name)
                 # if distributed:

--- a/workflow/lib/idds/workflowv2/workflow.py
+++ b/workflow/lib/idds/workflowv2/workflow.py
@@ -1590,9 +1590,11 @@ class WorkflowBase(Base):
 
         # make sure internal_id is loaded
         internal_id_relation_map = self.internal_id_relation_map
+        self.logger.debug(f"internal_id_relation_map: {internal_id_relation_map}")
         if internal_id_relation_map and works:
             for i, w in enumerate(works):
                 if not works[i].parent_internal_id:
+                    self.logger.debug(f"internal_id {works[i].internal_id} loads parent_internal_id {works[i].parent_internal_id}")
                     works[i].parent_internal_id = internal_id_relation_map.get(works[i].internal_id, None)
         return works
 


### PR DESCRIPTION
(1) functions to map iworkflow inputs and outputs between a task-chain
(2) fix the disorder issue because the parent_internal_id was not stored in database (it was only calculated in a process, when an agent is interrupt this part, the new agent will not have the parent_internal_id information. As a result, the order will not be respected).