### PR TITLE
fix(marshaller): pass transform errors to work terminated message

### DIFF
--- a/main/lib/idds/agents/marshaller/marshaller.py
+++ b/main/lib/idds/agents/marshaller/marshaller.py
@@ -174,7 +174,6 @@ class Marshaller(BaseAgent):
         if workprogress['status'] in [WorkprogressStatus.ToCancel]:
             # current works
             works = wf.get_current_works()
-            # print(works)
             for work in works:
                 if work.get_status() not in [WorkStatus.Finished, WorkStatus.SubFinished,
                                              WorkStatus.Failed, WorkStatus.Cancelling,
@@ -183,13 +182,12 @@ class Marshaller(BaseAgent):
 
         # current works
         works = wf.get_current_works()
-        # print(works)
         for work in works:
-            # print(work.get_work_id())
             tf = core_transforms.get_transform(transform_id=work.get_work_id())
             work_status = WorkStatus(tf['status'].value)
             work.set_status(work_status)
-            work.set_terminated_msg(msg=None)   # TODO
+            # Pass transform errors as the terminated message for proper error propagation
+            work.set_terminated_msg(msg=tf.get('errors'))
 
         if wf.is_terminated():
             if wf.is_finished():


### PR DESCRIPTION
Previously, set_terminated_msg was called with msg=None (marked as TODO), which meant error information from transforms was not propagated to works.

Changes:
- Pass tf.get('errors') to set_terminated_msg() for proper error propagation
- Remove commented-out debug print statements
- Enables workflow to properly display error messages from failed transforms

This fix ensures that when a transform fails, the error information is properly passed through the work object to the workflow's terminated message, improving debugging and error visibility.