### PR TITLE
Fix {python_version} placeholder not substituted in alembic.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,8 @@ RUN source /etc/profile.d/conda.sh; conda activate /opt/idds; \
   if [[ -z "$TAG" ]] ; then \
   python3 build_all.py wheel && main/tools/env/install_packages.sh ; \
   else \
-  python3 -m pip install --no-cache-dir --upgrade idds-common==$TAG idds-workflow==$TAG idds-server==$TAG idds-client==$TAG idds-doma==$TAG idds-atlas==$TAG idds-website==$TAG idds-monitor==$TAG ; \
+  python3 -m pip install --no-cache-dir --upgrade idds-common==$TAG idds-workflow==$TAG idds-server==$TAG idds-client==$TAG idds-doma==$TAG idds-atlas==$TAG idds-website==$TAG idds-monitor==$TAG && \
+  python3 build_all.py fix_python_version; \
   fi
 
 WORKDIR /tmp

--- a/build_all.py
+++ b/build_all.py
@@ -152,7 +152,11 @@ def main():
         sys.exit(1)
     
     command = sys.argv[1]
-    
+
+    if command == 'fix_python_version':
+        fix_alembic_ini_python_version()
+        return
+
     # Check if pip and build are available
     if command in ['build', 'wheel']:
         try:
@@ -161,7 +165,7 @@ def main():
             print("ERROR: 'build' package not found. Install it with:")
             print("    pip install build")
             sys.exit(1)
-    
+
     process_packages(command)
 
 

--- a/start-daemon.sh
+++ b/start-daemon.sh
@@ -57,6 +57,8 @@ else
     python3 /opt/idds/tools/env/merge_configmap.py \
         -s /opt/idds/configmap/idds_configmap.json \
         -d /opt/idds/config/idds/alembic.ini
+    PY_VER=$(python3 -c "import sys; print('python{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
+    sed -i "s|{python_version}|${PY_VER}|g" /opt/idds/config/idds/alembic.ini
 fi
 
 if [ -f /opt/idds/config/idds/auth.cfg ]; then


### PR DESCRIPTION
When the Docker image is built with a specific release tag (the `pip install` path in `Dockerfile`), `build_all.py` is not invoked and the `{python_version}` placeholder in `config_default/alembic.ini` is never resolved. At container startup `start-daemon.sh` copies the unresolved template verbatim, causing Alembic to fail with:

```
CommandError: Path doesn't exist:
  /opt/idds/lib/{python_version}/site-packages/idds/orm/base/alembic.
  Please use the 'init' command to create a new scripts folder.
```

This means neither `create_database.py` nor `alembic upgrade heads` can connect to the script directory, so schema migrations are silently skipped on every container start.

Three coordinated fixes:

**`start-daemon.sh`** — resolve `{python_version}` at runtime immediately after generating `alembic.ini`. This is the primary fix and works regardless of how the image was built.

**`Dockerfile`** — call `python3 build_all.py fix_python_version` after `pip install` in the tag-based build path so the installed `config_default/alembic.ini` is resolved at image build time as well.

**`build_all.py`** — expose `fix_alembic_ini_python_version()` as the `fix_python_version` subcommand so the Dockerfile can invoke it cleanly.