### PR TITLE
Activate Oracle thick mode in the alembic migration engine

### DIFF
--- a/main/lib/idds/orm/base/alembic/env.py
+++ b/main/lib/idds/orm/base/alembic/env.py
@@ -9,6 +9,7 @@
 # - Wen Guan, <wen.guan@cern.ch>, 2023
 
 
+import logging
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -18,6 +19,8 @@ from alembic import context
 
 # from idds.orm.base.models import Base
 from idds.orm.base.session import BASE
+
+LOG = logging.getLogger(__name__)
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -77,8 +80,20 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    section = config.get_section(config.config_ini_section)
+    sql_connection = section.get("sqlalchemy.url", "")
+    if 'oracledb' in sql_connection:
+        # mirrors idds.orm.base.session's engine creation: without this, oracledb defaults
+        # to thin mode, which does not support Oracle Native Network Encryption and fails
+        # to connect against database servers that require it.
+        try:
+            import oracledb  # pylint: disable=import-error
+            oracledb.init_oracle_client()
+        except Exception as err:
+            LOG.warning('Could not start Oracle thick mode; falling back to thin: %s', err)
+
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        section,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )


### PR DESCRIPTION
\`run_migrations_online()\` in \`main/lib/idds/orm/base/alembic/env.py\` creates its own SQLAlchemy engine via \`engine_from_config()\`. It only imports \`BASE\` (the metadata) from \`idds.orm.base.session\`, not that module's engine-creation logic — which is the only place in the codebase that calls \`oracledb.init_oracle_client()\` to activate Oracle thick mode. So the alembic migration path always connects via \`oracledb\`'s default thin mode.

Thin mode does not support Oracle Native Network Encryption. Against a database server that requires it, every connection attempt raises \`DPY-3001\`/\`DPY-6005\`. Since this migration runs synchronously before the REST service starts (see \`start-daemon.sh\`), affected deployments never become ready — the container just sits there, silent, until it's eventually killed by the liveness probe and restarted, forever.

I ran into this directly on a real deployment (PanDA/ATLAS testbed). The confusing part: the same DPY-3001 error also shows up harmlessly elsewhere in the logs on a healthy, long-running pod, so it initially looked unrelated — it took a while to pin down that it's specifically this migration step blocking startup.

To confirm this is precisely the missing piece and not an environment/packaging issue, I exec'd into the running container and called \`oracledb.init_oracle_client()\` directly in the same conda env — it succeeded immediately (the Instant Client libraries the Dockerfile installs are present and correctly registered via ldconfig). So thick mode is fully available in the image; it's just never activated on this one code path.

This PR mirrors \`session.py\`'s existing pattern (same \`if 'oracledb' in sql_connection\` check, same try/except with a warning fallback) in \`run_migrations_online()\`, so the migration engine gets the same thick-mode activation as the main application engine.