### PR TITLE
Fix chain.pem fallback ordering in start-daemon.sh

### DIFF
--- a/start-daemon.sh
+++ b/start-daemon.sh
@@ -26,14 +26,6 @@ elif [ -f /opt/idds/certs/hostkey.pem ]; then
     ln -fs /opt/idds/certs/hostcert.pem /etc/grid-security/hostcert.pem
     chmod 600 /etc/grid-security/hostkey.pem
 fi
-# setup intermediate certificate
-if [ ! -f /etc/grid-security/chain.pem ]; then
-  if [ -f /opt/idds/certs/chain.pem ]; then
-    ln -fs /opt/idds/certs/chain.pem /etc/grid-security/chain.pem
-  elif [ -f /etc/grid-security/hostcert.pem ]; then
-    ln -fs /etc/grid-security/hostcert.pem /etc/grid-security/chain.pem
-  fi
-fi
 
 if [ -f /opt/idds/config/idds/idds.cfg ]; then
     echo "idds.cfg already mounted."
@@ -183,6 +175,18 @@ else
     ln -fs /opt/idds/config/hostcert.pem /etc/grid-security/hostcert.pem
     ln -fs /opt/idds/config/hostkey.pem /etc/grid-security/hostkey.pem
     chmod 600 /etc/grid-security/hostkey.pem
+fi
+
+# setup intermediate certificate - this must run after the host certificate is in
+# place (either mounted or self-signed above), otherwise the self-signed case never
+# has a hostcert.pem to fall back to and chain.pem is left missing, which makes
+# httpd refuse to start (SSLCertificateChainFile: file does not exist or is empty).
+if [ ! -f /etc/grid-security/chain.pem ]; then
+  if [ -f /opt/idds/certs/chain.pem ]; then
+    ln -fs /opt/idds/certs/chain.pem /etc/grid-security/chain.pem
+  elif [ -f /etc/grid-security/hostcert.pem ]; then
+    ln -fs /etc/grid-security/hostcert.pem /etc/grid-security/chain.pem
+  fi
 fi
 
 cp /opt/idds/config_default/httpd_daemon.sh /opt/idds/config/idds/httpd_daemon.sh


### PR DESCRIPTION
The intermediate certificate (chain.pem) setup in start-daemon.sh runs before the self-signed host certificate fallback further down the script. When no real certificate is mounted at all, its own fallback path (symlink hostcert.pem as chain.pem when no chain.pem is provided) checks for a hostcert.pem that does not exist yet at that point, since the self-signed one has not been generated. chain.pem is then left missing entirely.

httpd then refuses to start:

SSLCertificateChainFile: file '/etc/grid-security/chain.pem' does not exist or is empty

which crash-loops the whole pod, since start-daemon.sh runs httpd under supervisord alongside the rest of the daemon agents.

We hit this directly on a PanDA/iDDS deployment where the certificate secret was empty, forcing the self-signed fallback path. Moving the chain.pem block to run after the self-signed certificate generation means hostcert.pem always exists by the time the fallback checks for it, while leaving the already-working "real certificate mounted" case untouched.