### PR TITLE
mark lost when a rule cannot be found

### DIFF
--- a/atlas/lib/idds/atlas/processing/stagein_poller.py
+++ b/atlas/lib/idds/atlas/processing/stagein_poller.py
@@ -6,7 +6,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0OA
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2019-2020
+# - Wen Guan, <wen.guan@cern.ch>, 2019-2026
 
 
 """

--- a/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
@@ -380,7 +380,7 @@ class ATLASStageinWork(DataWork):
             return processing_status, updated_contents, {}, updated_contents_full, {}
         except exceptions.ProcessNotFound as ex:
             self.logger.warn("processing_id %s not not found: %s" % (processing['processing_id'], str(ex)))
-            processing_status = ProcessingStatus.Failed
+            processing_status = ProcessingStatus.Lost
             return processing_status, [], {}, [], {}
         except Exception as ex:
             self.logger.error(ex)

--- a/main/lib/idds/agents/carrier/utils.py
+++ b/main/lib/idds/agents/carrier/utils.py
@@ -102,7 +102,8 @@ def is_process_terminated(processing_status):
                              ProcessingStatus.SubFinished, ProcessingStatus.Cancelled,
                              ProcessingStatus.Suspended, ProcessingStatus.Expired,
                              ProcessingStatus.Broken, ProcessingStatus.FinishedOnStep,
-                             ProcessingStatus.FinishedOnExec, ProcessingStatus.FinishedTerm]:
+                             ProcessingStatus.FinishedOnExec, ProcessingStatus.FinishedTerm,
+                             ProcessingStatus.Lost]:
         return True
     return False
 
@@ -3014,7 +3015,7 @@ def sync_processing(processing, agent_attributes, terminate=False, abort=False, 
     logger = get_logger()
 
     terminated_status = [ProcessingStatus.Finished, ProcessingStatus.Failed, ProcessingStatus.SubFinished,
-                         ProcessingStatus.Terminating, ProcessingStatus.Cancelled]
+                         ProcessingStatus.Terminating, ProcessingStatus.Cancelled, ProcessingStatus.Lost]
 
     request_id = processing['request_id']
     transform_id = processing['transform_id']
@@ -3034,6 +3035,9 @@ def sync_processing(processing, agent_attributes, terminate=False, abort=False, 
         terminate = True
     is_cancelled = processing.get('substatus') in [ProcessingStatus.Cancelled, ProcessingStatus.Suspended]
     if is_cancelled:
+        abort = True
+    is_lost = processing.get('substatus') in [ProcessingStatus.Lost]
+    if is_lost:
         abort = True
     update_collections, all_updates_flushed, msgs = sync_collection_status_new(request_id, transform_id, workload_id, work,
                                                                                log_prefix=log_prefix,


### PR DESCRIPTION
When a rule was not found, iDDS originaly will keep querying this request for a long time. It caused a lot of requests to query. The updates will mark these processings as lost and fail these requests immediately.