### PR TITLE
Fix NATS timeout exception handling in the coordinator

### DIFF
--- a/main/lib/idds/agents/coordinator/nats_coordinator.py
+++ b/main/lib/idds/agents/coordinator/nats_coordinator.py
@@ -86,7 +86,12 @@ class IDDSNATS(Singleton):
                 data_all.append(data)
             if self.logger:
                 self.logger.debug(f"Fetched events from {event_type_name} using durable {durable}: {data_all}")
-        except NATSTimeoutError:
+        except (NATSTimeoutError, asyncio.TimeoutError):
+            # a normal "no messages available within the wait window" result,
+            # not an error - nats-py's pull_subscribe().fetch() can raise
+            # either its own TimeoutError or the plain asyncio one depending
+            # on the code path, so both need to be caught here to avoid
+            # logging this at ERROR level on every idle poll
             pass
         except NATSNotFoundError:
             if self.logger:
@@ -136,10 +141,13 @@ class IDDSNATS(Singleton):
                 await nc.close()
                 if self.debug_mode and self.logger:
                     self.logger.debug("NATS connection drained and closed")
+        except (NATSTimeoutError, asyncio.TimeoutError):
+            # must come before the generic Exception handler below, otherwise
+            # this is unreachable dead code since NATSTimeoutError is itself
+            # an Exception subclass
+            pass
         except Exception as ex:
             self.logger.error(f"Failed to close connection: {ex}")
-        except NATSTimeoutError:
-            pass
 
 
 class NATSCoordinator(BaseAgent):


### PR DESCRIPTION
fetch_events() only caught nats.errors.TimeoutError, but confirmed directly against a live idds-rest deployment that subscriber.fetch(num_events, timeout=wait) actually raises the plain asyncio.TimeoutError in this case, not the nats-specific one - its str() is empty, which matches exactly what we saw in production: thousands of "Failed to fetch event.Message: " ERROR log lines with no message body, on an idle system with nothing actually failing (confirmed via `str(asyncio.TimeoutError())` == `''` vs `str(nats.errors.TimeoutError())` == `'nats: timeout'`).

Catching both exception types restores the intended silent handling of an ordinary "no messages within the wait window" result - not a real error, and not a retry loop, just noisy/incorrect log-level classification.

Also fixes a related dead-code bug in close(): its `except NATSTimeoutError` clause was placed after `except Exception`, making it unreachable since NATSTimeoutError is itself an Exception subclass. Reordered and extended it the same way as fetch_events().