### PR TITLE
Fix docstring typos (catagories/fist, enviroment)

### DIFF
--- a/atlas/lib/idds/atlas/workflow/atlasactuatorwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasactuatorwork.py
@@ -40,7 +40,7 @@ class ATLASActuatorWork(ATLASCondorWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflow/atlascondorwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlascondorwork.py
@@ -26,7 +26,7 @@ class ATLASCondorWork(Work):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflow/atlasdagwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasdagwork.py
@@ -46,7 +46,7 @@ class DomaLSSTWork(Work):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflow/atlashpowork.py
+++ b/atlas/lib/idds/atlas/workflow/atlashpowork.py
@@ -44,7 +44,7 @@ class ATLASHPOWork(ATLASCondorWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
@@ -37,7 +37,7 @@ class ATLASStageinWork(DataWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflowv2/atlasactuatorwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasactuatorwork.py
@@ -40,7 +40,7 @@ class ATLASActuatorWork(ATLASCondorWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflowv2/atlascondorwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlascondorwork.py
@@ -26,7 +26,7 @@ class ATLASCondorWork(Work):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflowv2/atlasdagwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasdagwork.py
@@ -46,7 +46,7 @@ class DomaLSSTWork(Work):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflowv2/atlashpowork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlashpowork.py
@@ -44,7 +44,7 @@ class ATLASHPOWork(ATLASCondorWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/atlas/lib/idds/atlas/workflowv2/atlasstageinwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasstageinwork.py
@@ -37,7 +37,7 @@ class ATLASStageinWork(DataWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/common/lib/idds/common/exceptions.py
+++ b/common/lib/idds/common/exceptions.py
@@ -12,11 +12,11 @@
 IDDS Exceptions.
 
 error codes:
-    The fist the number is one of the main catagories.
-    The second number is one of the subcatagories.
-    The third number and numbers after third one are local defined for every subcatagory.
+    The first number is one of the main categories.
+    The second number is one of the subcategories.
+    The third number and numbers after third one are local defined for every subcategory.
 
-Catagories:
+Categories:
  1. common/unknown IDDS exception
  2. ORM related exception
     1. request table related exception

--- a/doma/lib/idds/doma/workflowv2/domadatawork.py
+++ b/doma/lib/idds/doma/workflowv2/domadatawork.py
@@ -35,7 +35,7 @@ class DomaDataWork(DataWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/doma/lib/idds/doma/workflowv2/domaruciowork.py
+++ b/doma/lib/idds/doma/workflowv2/domaruciowork.py
@@ -35,7 +35,7 @@ class DomaRucioWork(DataWork):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/workflow/lib/idds/workflow/work.py
+++ b/workflow/lib/idds/workflow/work.py
@@ -444,7 +444,7 @@ class Work(Base):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.

--- a/workflow/lib/idds/workflowv2/work.py
+++ b/workflow/lib/idds/workflowv2/work.py
@@ -448,7 +448,7 @@ class Work(Base):
         """
         Init a work/task/transformation.
 
-        :param setup: A string to setup the executable enviroment, it can be None.
+        :param setup: A string to setup the executable environment, it can be None.
         :param executable: The executable.
         :param arguments: The arguments.
         :param parameters: A dict with arguments needed to be replaced.


### PR DESCRIPTION
exceptions.py's error code docstring had "fist"/"catagories" instead of "first"/"categories", plus a duplicated "the".

Separately, ":param setup: ... executable enviroment ..." is a copy-pasted docstring line with the same "enviroment" typo across 14 workflow/work files - fixed all occurrences.

No behavioral changes, docstrings/comments only.