### PR TITLE
Fix more docstring/comment/log-message typos

### DIFF
--- a/atlas/lib/idds/atlas/workflow/atlasactuatorwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasactuatorwork.py
@@ -225,7 +225,7 @@ class ATLASActuatorWork(ATLASCondorWork):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and 'status' in self.collections[self._primary_input_collection]
            and self.collections[self._primary_input_collection]['status'] in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)

--- a/atlas/lib/idds/atlas/workflow/atlasdagwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasdagwork.py
@@ -256,7 +256,7 @@ class DomaLSSTWork(Work):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if not new_inputs and self.collections[self._primary_input_collection]['status'] in [CollectionStatus.Closed]:
             self.set_has_new_inputs(False)
         else:

--- a/atlas/lib/idds/atlas/workflow/atlaspandawork.py
+++ b/atlas/lib/idds/atlas/workflow/atlaspandawork.py
@@ -447,7 +447,7 @@ class ATLASPandaWork(Work):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and self.collections[self._primary_input_collection].status in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)
         else:

--- a/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
+++ b/atlas/lib/idds/atlas/workflow/atlasstageinwork.py
@@ -194,7 +194,7 @@ class ATLASStageinWork(DataWork):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and self.collections[self._primary_input_collection].status in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)
         else:

--- a/atlas/lib/idds/atlas/workflowv2/atlasactuatorwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasactuatorwork.py
@@ -225,7 +225,7 @@ class ATLASActuatorWork(ATLASCondorWork):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and 'status' in self.collections[self._primary_input_collection]
            and self.collections[self._primary_input_collection]['status'] in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)

--- a/atlas/lib/idds/atlas/workflowv2/atlasdagwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasdagwork.py
@@ -256,7 +256,7 @@ class DomaLSSTWork(Work):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if not new_inputs and self.collections[self._primary_input_collection]['status'] in [CollectionStatus.Closed]:
             self.set_has_new_inputs(False)
         else:

--- a/atlas/lib/idds/atlas/workflowv2/atlaspandawork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlaspandawork.py
@@ -462,7 +462,7 @@ class ATLASPandaWork(Work):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and self.collections[self._primary_input_collection].status in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)
         else:

--- a/atlas/lib/idds/atlas/workflowv2/atlasstageinwork.py
+++ b/atlas/lib/idds/atlas/workflowv2/atlasstageinwork.py
@@ -194,7 +194,7 @@ class ATLASStageinWork(DataWork):
             if ip_scope_name not in mapped_inputs_scope_name:
                 new_inputs.append(ip)
 
-        # to avoid cheking new inputs if there are no new inputs anymore
+        # to avoid checking new inputs if there are no new inputs anymore
         if (not new_inputs and self.collections[self._primary_input_collection].status in [CollectionStatus.Closed]):  # noqa: W503
             self.set_has_new_inputs(False)
         else:

--- a/common/lib/idds/common/utils.py
+++ b/common/lib/idds/common/utils.py
@@ -730,7 +730,7 @@ def get_parameters_from_string(text):
     """
     ret = re.findall(r"[%]\w+", text)
     ret = [r.replace("%", "") for r in ret]
-    # remove dumplications
+    # remove duplications
     ret = list(set(ret))
     return ret
 
@@ -1053,7 +1053,7 @@ def decode_base64(sb, remove_quotes=False):
         else:
             return sb
         decode_str = base64.b64decode(sb_bytes).decode("utf-8")
-        # remove the single quotes afeter decoding
+        # remove the single quotes after decoding
         if remove_quotes:
             return decode_str[1:-1]
         return decode_str

--- a/doma/lib/idds/doma/workflowv2/domapandaeswork.py
+++ b/doma/lib/idds/doma/workflowv2/domapandaeswork.py
@@ -74,7 +74,7 @@ class DomaPanDAESWork(DomaPanDAWork):
         if value:
             if type(value) not in [dict]:
                 raise exceptions.IDDSException("ES dependency_map should be a dict")
-            # the dumplication is already verified in DomaEventMap, not do it again here
+            # the duplication is already verified in DomaEventMap, not do it again here
 
         self._es_dependency_map = value
 

--- a/main/lib/idds/agents/clerk/clerk.py
+++ b/main/lib/idds/agents/clerk/clerk.py
@@ -2014,7 +2014,7 @@ class Clerk(BaseAgent):
                 elif req['request_type'] in [RequestType.iWorkflow, RequestType.iWorkflowLocal]:
                     ret = self.handle_resume_irequest(req)
                     self.update_request(ret, origin_req=req)
-                    # self.handle_command(event, cmd_status=CommandStatus.Failed, errors="Not support to reusme for iWorkflow")
+                    # self.handle_command(event, cmd_status=CommandStatus.Failed, errors="Not support to resume for iWorkflow")
                     self.handle_command(event, command=command, cmd_status=CommandStatus.Processed, errors=None)
                 else:
                     ret = self.handle_resume_request(req)

--- a/main/lib/idds/agents/transporter/transporter.py
+++ b/main/lib/idds/agents/transporter/transporter.py
@@ -181,7 +181,7 @@ class Transporter(BaseAgent):
     def finish_processing_input_collections(self):
         while not self.processed_input_queue.empty():
             coll = self.processed_input_queue.get()
-            self.logger.info("Main thread finished processing intput collection(%s) with number of contents: %s" % (coll['coll']['coll_id'], len(coll['contents'])))
+            self.logger.info("Main thread finished processing input collection(%s) with number of contents: %s" % (coll['coll']['coll_id'], len(coll['contents'])))
             parameters = copy.deepcopy(coll)
             if parameters['coll']['coll_type'] in [CollectionType.PseudoDataset, CollectionType.PseudoDataset.value]:
                 pass

--- a/main/lib/idds/tests/test_activelearning.py
+++ b/main/lib/idds/tests/test_activelearning.py
@@ -131,7 +131,7 @@ def get_workflow():
     work = ATLASPandaWork(panda_task_paramsmap=task_param_map)
 
     # it's needed to parse the panda task parameter information, for example output dataset name, for the next task.
-    # if the information is not needed, you don't need to run it manually. iDDS will call it interally to parse the information.
+    # if the information is not needed, you don't need to run it manually. iDDS will call it internally to parse the information.
     work.initialize_work()
 
     work_output_coll = work.get_output_collections()[0]

--- a/main/lib/idds/tests/test_workflow_condition.py
+++ b/main/lib/idds/tests/test_workflow_condition.py
@@ -10,7 +10,7 @@
 
 
 """
-Test workflow condtions.
+Test workflow conditions.
 """
 
 import unittest2 as unittest

--- a/main/lib/idds/tests/test_workflow_condition_v2.py
+++ b/main/lib/idds/tests/test_workflow_condition_v2.py
@@ -10,7 +10,7 @@
 
 
 """
-Test workflow condtions.
+Test workflow conditions.
 """
 
 import unittest2 as unittest

--- a/main/lib/idds/tests/test_workflow_condition_v2_1.py
+++ b/main/lib/idds/tests/test_workflow_condition_v2_1.py
@@ -10,7 +10,7 @@
 
 
 """
-Test workflow condtions.
+Test workflow conditions.
 """
 
 # import json

--- a/workflow/lib/idds/workflow/workflow.py
+++ b/workflow/lib/idds/workflow/workflow.py
@@ -302,7 +302,7 @@ class CompositeCondition(Base):
         new_false_works = []
         for w in self.false_works:
             if isinstance(w, CompositeCondition):
-                # work = w.load_condtions(works, works_template)
+                # work = w.load_conditions(works, works_template)
                 w.load_conditions(works)
                 work = w
             elif isinstance(w, Workflow):

--- a/workflow/lib/idds/workflowv2/workflow.py
+++ b/workflow/lib/idds/workflowv2/workflow.py
@@ -336,7 +336,7 @@ class CompositeCondition(Base):
         new_false_works = []
         for w in self.false_works:
             if isinstance(w, CompositeCondition):
-                # work = w.load_condtions(works, works_template)
+                # work = w.load_conditions(works, works_template)
                 w.load_conditions(works)
                 work = w
             elif isinstance(w, Workflow):


### PR DESCRIPTION
More of the same class as #567: afeter, dumplication(s), cheking, interally, intput, condtions, reusme, signleton - across comments, docstrings, test module docstrings, and one log message string.

No behavioral changes. Two related-but-different findings (actual misspelled function calls, not just text) are intentionally left out of this PR and will follow separately.