### PR TITLE
Fix two misspelled function references in unused code paths

### DIFF
--- a/main/lib/idds/agents/common/timerscheduler.py
+++ b/main/lib/idds/agents/common/timerscheduler.py
@@ -111,7 +111,7 @@ class TimerScheduler(threading.Thread):
         self.executor_name = name
         self.use_process_pool = use_process_pool
 
-        # self.executors = self.get_executor_signleton()
+        # self.executors = self.get_executor_singleton()
         self.executors = self.get_executor()
 
         self.executors_timer = IDDSThreadPoolExecutor(max_workers=1,
@@ -129,7 +129,7 @@ class TimerScheduler(threading.Thread):
         else:
             return IDDSThreadPoolExecutor(max_workers=self.num_threads, thread_name_prefix=self.executor_name)
 
-    def get_executor_signleton(self):
+    def get_executor_singleton(self):
         with TimerScheduler._singleton_lock:
             if self.use_process_pool:
                 if TimerScheduler._process_executor is None:

--- a/main/lib/idds/core/conditions.py
+++ b/main/lib/idds/core/conditions.py
@@ -101,4 +101,4 @@ def delete_conditions(request_id=None, internal_id=None, session=None):
     :param intenal_id: The internal id.
     :param session: The database session.
     """
-    orm_conditions.delete_condtions(request_id=request_id, internal_id=internal_id, session=session)
+    orm_conditions.delete_conditions(request_id=request_id, internal_id=internal_id, session=session)


### PR DESCRIPTION
core/conditions.py's delete_conditions() called orm_conditions.delete_condtions(), which doesn't exist - only delete_conditions (correct spelling) is defined in the ORM layer, and its signature matches exactly what's being passed here, so this is a straightforward rename.

TimerScheduler.get_executor_signleton() was defined with a typo in its own name; its only reference is a commented-out call in __init__, so renaming both is safe.

Both are currently unreachable/never called with live impact, but would crash with AttributeError immediately if ever invoked.

Left out of this PR: a third, related finding in agents/transformer/transformer.py's evaluate_conditions(), which calls a nonexistent core_conditions.get_condtions(). That one isn't a simple rename - even calling the closest matching function (retrieve_conditions) would still fail, since it's being invoked with keyword arguments (internal_ids, loop_index) that don't exist on any current function in the conditions module. Fixing that would mean redesigning how the method fetches conditions, not just correcting a name, so leaving it for whoever knows the intended behavior of that (currently uncalled) method.